### PR TITLE
Added option to mcsamplerEnsemble.py that allows user to specify number of Gaussian components for each dimension, or sample uniformly

### DIFF
--- a/MonteCarloMarginalizeCode/Code/RIFT/integrators/MonteCarloEnsemble.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/integrators/MonteCarloEnsemble.py
@@ -37,8 +37,10 @@ class integrator:
         two or more dimensions, they should be grouped. Each value is by default initialized
         to None, and is replaced with the GMM object for its dimension(s).
 
-    n_comp : int
-        The number of Gaussian components per group of dimensions.
+    n_comp : int or {tuple:int}
+        The number of Gaussian components per group of dimensions. If its type is int,
+        this number of components is used for all dimensions. If it is a dict, it maps
+        each key in gmm_dict to an integer number of mixture model components.
 
     n : int
         Number of samples per iteration
@@ -154,7 +156,10 @@ class integrator:
                 index += 1
             if model is None:
                 # model doesn't exist yet
-                model = GMM.gmm(self.n_comp)
+                if isinstance(self.n_comp, int):
+                    model = GMM.gmm(self.n_comp)
+                else:
+                    model = GMM.gmm(self.n_comp[dim_group])
                 model.fit(temp_samples, sample_weights=weights)
             else:
                 model.update(temp_samples, sample_weights=weights)

--- a/MonteCarloMarginalizeCode/Code/RIFT/integrators/MonteCarloEnsemble.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/integrators/MonteCarloEnsemble.py
@@ -156,10 +156,10 @@ class integrator:
                 index += 1
             if model is None:
                 # model doesn't exist yet
-                if isinstance(self.n_comp, int):
+                if isinstance(self.n_comp, int) and self.n_comp != 0:
                     model = GMM.gmm(self.n_comp)
                     model.fit(temp_samples, sample_weights=weights)
-                elif self.n_comp[dim_group] != 0:
+                elif isinstance(self.n_comp, dict) and self.n_comp[dim_group] != 0:
                     model = GMM.gmm(self.n_comp[dim_group])
                     model.fit(temp_samples, sample_weights=weights)
             else:

--- a/MonteCarloMarginalizeCode/Code/RIFT/integrators/MonteCarloEnsemble.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/integrators/MonteCarloEnsemble.py
@@ -158,9 +158,10 @@ class integrator:
                 # model doesn't exist yet
                 if isinstance(self.n_comp, int):
                     model = GMM.gmm(self.n_comp)
-                else:
+                    model.fit(temp_samples, sample_weights=weights)
+                elif self.n_comp[dim_group] != 0:
                     model = GMM.gmm(self.n_comp[dim_group])
-                model.fit(temp_samples, sample_weights=weights)
+                    model.fit(temp_samples, sample_weights=weights)
             else:
                 model.update(temp_samples, sample_weights=weights)
             self.gmm_dict[dim_group] = model

--- a/MonteCarloMarginalizeCode/Code/RIFT/integrators/mcsamplerEnsemble.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/integrators/mcsamplerEnsemble.py
@@ -256,13 +256,10 @@ class MCSampler(object):
             bounds.append([self.llim[param], self.rlim[param]])
         bounds = np.array(bounds)
 
-        # for now, we hardcode the assumption that there are no correlated dimensions,
-        # unless otherwise specified
+        # if the user does not provide gmm_dict, assume ALL dimensions are correlated
 
         if gmm_dict is None:
-            gmm_dict = {}
-            for x in range(dim):
-                gmm_dict[(x,)] = None
+            gmm_dict = {tuple(range(dim)):None}
 
         # do the integral
 

--- a/MonteCarloMarginalizeCode/Code/RIFT/integrators/mcsamplerEnsemble.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/integrators/mcsamplerEnsemble.py
@@ -241,6 +241,7 @@ class MCSampler(object):
         max_iter = kwargs['max_iter'] if kwargs.has_key('max_iter') else 20
         var_thresh = kwargs['var_thres'] if kwargs.has_key('var_thresh') else 0.05
         write_to_file = kwargs['write_to_file'] if kwargs.has_key('write_to_file') else False
+        correlate_all_dims = kwargs['correlate_all_dims'] if kwargs.has_key('correlate_all_dims') else False
 
         L_cutoff = kwargs["L_cutoff"] if kwargs.has_key("L_cutoff") else None
 
@@ -256,10 +257,14 @@ class MCSampler(object):
             bounds.append([self.llim[param], self.rlim[param]])
         bounds = np.array(bounds)
 
-        # if the user does not provide gmm_dict, assume ALL dimensions are correlated
-
+        # generate default gmm_dict if not specified
         if gmm_dict is None:
-            gmm_dict = {tuple(range(dim)):None}
+            if correlate_all_dims:
+                gmm_dict = {tuple(range(dim)):None}
+            else:
+                gmm_dict = {}
+                for i in range(dim):
+                    gmm_dict[(i,)] = None
 
         # do the integral
 

--- a/MonteCarloMarginalizeCode/Code/RIFT/integrators/mcsamplerEnsemble.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/integrators/mcsamplerEnsemble.py
@@ -278,8 +278,8 @@ class MCSampler(object):
         eff_samp = integrator.eff_samp
         sample_array = integrator.cumulative_samples
         value_array = integrator.cumulative_values
-        p_array = integrator.cumulative_p
-        prior_array = integrator.cumulative_p_s
+        p_array = integrator.cumulative_p_s
+        prior_array = integrator.cumulative_p
 
         # user-defined function
         if mcsamp_func is not None:

--- a/MonteCarloMarginalizeCode/Code/RIFT/integrators/mcsamplerEnsemble.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/integrators/mcsamplerEnsemble.py
@@ -242,7 +242,7 @@ class MCSampler(object):
         var_thresh = kwargs['var_thres'] if kwargs.has_key('var_thresh') else 0.05
         write_to_file = kwargs['write_to_file'] if kwargs.has_key('write_to_file') else False
         correlate_all_dims = kwargs['correlate_all_dims'] if kwargs.has_key('correlate_all_dims') else False
-
+        gmm_adapt = kwargs['gmm_adapt'] if kwargs.has_key('gmm_adapt') else None
         L_cutoff = kwargs["L_cutoff"] if kwargs.has_key("L_cutoff") else None
 
         # set up a lot of preliminary stuff


### PR DESCRIPTION
The `n_comp` argument passed to `MonteCarloEnsemble.py` can now be either an int or a dict.
If it is a non-zero int, it specifies the number of Gaussian components to use for every GMM.
If it is 0, all dimensions are sampled uniformly.
If it is a dict, it must map each tuple of dimensions (i.e. the keys in `gmm_dict`) to an int, which specifies the number of components for the corresponding GMM. If this int is 0, no GMM is used and those dimensions are sampled uniformly.