### PR TITLE
Updates to lalsimutils and CIP - take two

### DIFF
--- a/MonteCarloMarginalizeCode/Code/RIFT/lalsimutils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/lalsimutils.py
@@ -877,7 +877,7 @@ class ChooseWaveformParams:
         if p == 'q_mu':   # trivial, more important what is treated as constant
             return self.m2/self.m1  
         if p == 'chi2z_mu':
-            return P.s2z
+            return self.s2z
         if p == 'lambda_plus':
             # Designed to give the benefits of sampling in chi_eff, without introducing a transformation/prior that depends on mass
             return (self.lambda1+self.lambda2)/2.

--- a/MonteCarloMarginalizeCode/Code/RIFT/lalsimutils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/lalsimutils.py
@@ -1061,98 +1061,111 @@ class ChooseWaveformParams:
             Sp = np.max([np.linalg.norm( A1*S1p), np.linalg.norm(A2*S2p)])
             return Sp/(A1*m1**2)  # divide by term for *larger* BH
         if p == 'chi_pavg':
-            # implementation of the averaged precession parameter from https://arxiv.org/pdf/2011.11948.pdf
-            # CH 21
-            ##########################################
-            G_SI = 6.67e-11 #SI units [m^3 kg^-1 s^-2]
-            c_SI = 2.99e8 #SI units [m s^-1]
-            SM = 1.98847e30 #Solar Mass in [kg]
-            conv = SM*G_SI/c_SI**3 #converts [SM] to [s kg^-1]
-            m1 = conv*self.extract_param('m1') #mass of object 1
-            m2 = conv*self.extract_param('m2') #mass of object 2
-            q = m2/m1 #mass ratio
-            thetaJN,phiJL,theta1,theta2,phi12,chi1,chi2,psiJ = self.extract_system_frame() #inheriting values from system
-            deltaphi = phi12
-            #implementation
-            if self.fref == 0:
-                fref = 20 #default fixed frequency value
+            if (abs(self.s1x) < 1e-4 and abs(self.s1y) < 1e-4 and abs(self.s2x) < 1e-4 and abs(self.s2y) < 1e-4):
+                chipavg = 0.0
+            elif (abs(self.s1x) < 1e-4 and abs(self.s1y) < 1e-4 and abs(self.s1z) < 1e-4) or (abs(self.s2x) < 1e-4 and abs(self.s2y) < 1e-4 and abs(self.s2z) < 1e-4):
+                chipavg = self.extract_param('chi_p')
             else:
-                fref = self.fref #user spec
-            def ftor_PN(f, q, chi1, chi2, theta1, theta2, deltaphi):
-                '''Convert GW frequency to PN orbital separation conversion'''
-                om = np.pi * f 
-                M_sec = m1 + m2
-                mom = M_sec * om                
-                eta = m1*m2
-                ct1 = np.cos(theta1)
-                ct2 = np.cos(theta2)
-                ct12 = np.sin(theta1) * np.sin(theta2) * np.cos(deltaphi) + ct1 * ct2
-                # Eq. 4.13, Kidder 1995. gr-qc/9506022
-                r = (mom)**(-2./3.)*(1. \
-                                - (1./3.)*(3.-eta)*mom**(2./3.)  \
-                                - (1./3.)* ( chi1*ct1*(2.*m1**2.+3.*eta) + chi2*ct2*(2.*m2**2.+3.*eta))*mom \
-                                + ( eta*(19./4. + eta/9.) -eta*chi1*chi2/2. * (ct12 - 3.*ct1*ct2 ))*mom**(4./3.)\
-                                )
-                return r
-            def omegatilde(q):
-                '''Ratio between the spin frequency, leading order term. Eq (13)'''
-                return q*(4*q+3)/(4+3*q)
-            def chip_terms(q,chi1,chi2,theta1,theta2):
-                '''Two chip terms'''
-                term1 = chi1*np.sin(theta1)
-                term2 = omegatilde(q) * chi2*np.sin(theta2)
-                return term1,term2
-            def chip_generalized(q,chi1,chi2,theta1,theta2,deltaphi):
-                '''Generalized definition of chip. Eq (15)'''
-                term1, term2 = chip_terms(q,chi1,chi2,theta1,theta2)
-                return (term1**2 + term2**2 + 2*term1*term2*np.cos(deltaphi))**0.5
-            @np.vectorize
-            def chip_averaged(q,chi1,chi2,theta1,theta2,deltaphi,r=None,fref=None):
-                '''Averaged definition of chip. Eq (15) and Appendix A'''
-                # Convert frequency to separation, if necessary
-                if r is None and fref is None: raise ValueError
-                elif r is not None and fref is not None: raise ValueError
-                if r is None:
-                    # Eq A1
-                    r = ftor_PN(fref, q, chi1, chi2, theta1, theta2, deltaphi)
-                #Compute constants of motion
-                L = (r**0.5)*q/(1+q)**2
-                S1 = chi1/(1.+q)**2
-                S2 = (q**2)*chi2/(1.+q)**2
-                # Eq 5
-                chieff = (chi1*np.cos(theta1)+q*chi2*np.cos(theta2))/(1+q)
-                # Eq A2
-                J = (L**2 + S1**2 + S2**2 + 2*L*(S1*np.cos(theta1) + S2*np.cos(theta2)) + 2*S1*S2*(np.sin(theta1)*np.sin(theta2)*np.cos(deltaphi) + np.cos(theta1)*np.cos(theta2)))**0.5
-                # Solve dSdt=0. Details in arXiv:1506.03492
-                Sminus,Splus=precession.Sb_limits(chieff,J,q,S1,S2,r)
-                def integrand_numerator(S):
-                    '''chip(S)/dSdt(S)'''
-                    #Eq A3
-                    theta1ofS = np.arccos( (1/(2*(1-q)*S1)) * ( (J**2-L**2-S**2)/L - 2*q*chieff/(1+q) ) )
-                    #Eq A4
-                    theta2ofS = np.arccos( (q/(2*(1-q)*S2)) * ( -(J**2-L**2-S**2)/L + 2*chieff/(1+q) ) )
-                    # Eq A5
-                    deltaphiofS = np.arccos( ( S**2-S1**2-S2**2 - 2*S1*S2*np.cos(theta1ofS)*np.cos(theta2ofS) ) / (2*S1*S2*np.sin(theta1ofS)*np.sin(theta2ofS)) )
-                    # Eq A6 (prefactor cancels out)
-                    dSdtofS = np.sin(theta1ofS)*np.sin(theta2ofS)*np.sin(deltaphiofS)/S
-                    # Eq (15)
-                    chipofS = chip_generalized(q,chi1,chi2,theta1ofS,theta2ofS,deltaphiofS)
-                    return chipofS/dSdtofS
-                numerator = scipy.integrate.quad(integrand_numerator, Sminus, Splus)[0]
-                def integrand_denominator(S):
-                    '''1/dSdt(S)'''
-                    #Eq A3
-                    theta1ofS = np.arccos( (1/(2*(1-q)*S1)) * ( (J**2-L**2-S**2)/L - 2*q*chieff/(1+q) ) )
-                    #Eq A4
-                    theta2ofS = np.arccos( (q/(2*(1-q)*S2)) * ( -(J**2-L**2-S**2)/L + 2*chieff/(1+q) ) )
-                    # Eq A5
-                    deltaphiofS = np.arccos( ( S**2-S1**2-S2**2 - 2*S1*S2*np.cos(theta1ofS)*np.cos(theta2ofS) ) / (2*S1*S2*np.sin(theta1ofS)*np.sin(theta2ofS)) )
-                    # Eq A6 (prefactor cancels out)
-                    dSdtofS = np.sin(theta1ofS)*np.sin(theta2ofS)*np.sin(deltaphiofS)/S
-                    return 1/dSdtofS
-                denominator = scipy.integrate.quad(integrand_denominator, Sminus, Splus)[0]
-                return numerator/denominator
-            return chip_averaged(q,chi1,chi2,theta1,theta2,deltaphi,fref=fref)    
+                try:
+                    # implementation of the averaged precession parameter from https://arxiv.org/pdf/2011.11948.pdf
+                    # CH 21
+                    ##########################################
+                    G_SI = 6.67e-11 #SI units [m^3 kg^-1 s^-2]
+                    c_SI = 2.99e8 #SI units [m s^-1]
+                    SM = 1.98847e30 #Solar Mass in [kg]
+                    conv = SM*G_SI/c_SI**3 #converts [SM] to [s kg^-1]
+                    if self.extract_param('m1') > 1e29:
+                        m1 = conv*self.extract_param('m1')/SM 
+                        m2 = conv*self.extract_param('m2')/SM
+                    else:
+                        m1 = conv*self.extract_param('m1')
+                        m2 = conv*self.extract_param('m2')
+                    q = m2/m1 #mass ratio
+                    thetaJN,phiJL,theta1,theta2,phi12,chi1,chi2,psiJ = self.extract_system_frame() #inheriting values from system
+                    deltaphi = phi12
+                    #implementation
+                    if self.fref == 0:
+                        fref = 20 #default fixed frequency value
+                    else:
+                        fref = self.fref #user spec
+                    def ftor_PN(f, q, chi1, chi2, theta1, theta2, deltaphi):
+                        '''Convert GW frequency to PN orbital separation conversion'''
+                        om = np.pi * f 
+                        M_sec = m1 + m2
+                        mom = M_sec * om                
+                        eta = m1*m2
+                        ct1 = np.cos(theta1)
+                        ct2 = np.cos(theta2)
+                        ct12 = np.sin(theta1) * np.sin(theta2) * np.cos(deltaphi) + ct1 * ct2
+                        # Eq. 4.13, Kidder 1995. gr-qc/9506022
+                        r = (mom)**(-2./3.)*(1. \
+                                        - (1./3.)*(3.-eta)*mom**(2./3.)  \
+                                        - (1./3.)* ( chi1*ct1*(2.*m1**2.+3.*eta) + chi2*ct2*(2.*m2**2.+3.*eta))*mom \
+                                        + ( eta*(19./4. + eta/9.) -eta*chi1*chi2/2. * (ct12 - 3.*ct1*ct2 ))*mom**(4./3.)\
+                                        )
+                        return r
+                    def omegatilde(q):
+                        '''Ratio between the spin frequency, leading order term. Eq (13)'''
+                        return q*(4*q+3)/(4+3*q)
+                    def chip_terms(q,chi1,chi2,theta1,theta2):
+                        '''Two chip terms'''
+                        term1 = chi1*np.sin(theta1)
+                        term2 = omegatilde(q) * chi2*np.sin(theta2)
+                        return term1,term2
+                    def chip_generalized(q,chi1,chi2,theta1,theta2,deltaphi):
+                        '''Generalized definition of chip. Eq (15)'''
+                        term1, term2 = chip_terms(q,chi1,chi2,theta1,theta2)
+                        return (term1**2 + term2**2 + 2*term1*term2*np.cos(deltaphi))**0.5
+                    @np.vectorize
+                    def chip_averaged(q,chi1,chi2,theta1,theta2,deltaphi,r=None,fref=None):
+                        '''Averaged definition of chip. Eq (15) and Appendix A'''
+                        # Convert frequency to separation, if necessary
+                        if r is None and fref is None: raise ValueError
+                        elif r is not None and fref is not None: raise ValueError
+                        if r is None:
+                            # Eq A1
+                            r = ftor_PN(fref, q, chi1, chi2, theta1, theta2, deltaphi)
+                        #Compute constants of motion
+                        L = (r**0.5)*q/(1+q)**2
+                        S1 = chi1/(1.+q)**2
+                        S2 = (q**2)*chi2/(1.+q)**2
+                        # Eq 5
+                        chieff = (chi1*np.cos(theta1)+q*chi2*np.cos(theta2))/(1+q)
+                        # Eq A2
+                        J = (L**2 + S1**2 + S2**2 + 2*L*(S1*np.cos(theta1) + S2*np.cos(theta2)) + 2*S1*S2*(np.sin(theta1)*np.sin(theta2)*np.cos(deltaphi) + np.cos(theta1)*np.cos(theta2)))**0.5
+                        # Solve dSdt=0. Details in arXiv:1506.03492
+                        Sminus,Splus=precession.Sb_limits(chieff,J,q,S1,S2,r)
+                        def integrand_numerator(S):
+                            '''chip(S)/dSdt(S)'''
+                            #Eq A3
+                            theta1ofS = np.arccos( (1/(2*(1-q)*S1)) * ( (J**2-L**2-S**2)/L - 2*q*chieff/(1+q) ) )
+                            #Eq A4
+                            theta2ofS = np.arccos( (q/(2*(1-q)*S2)) * ( -(J**2-L**2-S**2)/L + 2*chieff/(1+q) ) )
+                            # Eq A5
+                            deltaphiofS = np.arccos( ( S**2-S1**2-S2**2 - 2*S1*S2*np.cos(theta1ofS)*np.cos(theta2ofS) ) / (2*S1*S2*np.sin(theta1ofS)*np.sin(theta2ofS)) )
+                            # Eq A6 (prefactor cancels out)
+                            dSdtofS = np.sin(theta1ofS)*np.sin(theta2ofS)*np.sin(deltaphiofS)/S
+                            # Eq (15)
+                            chipofS = chip_generalized(q,chi1,chi2,theta1ofS,theta2ofS,deltaphiofS)
+                            return chipofS/dSdtofS
+                        numerator = scipy.integrate.quad(integrand_numerator, Sminus, Splus)[0]
+                        def integrand_denominator(S):
+                            '''1/dSdt(S)'''
+                            #Eq A3
+                            theta1ofS = np.arccos( (1/(2*(1-q)*S1)) * ( (J**2-L**2-S**2)/L - 2*q*chieff/(1+q) ) )
+                            #Eq A4
+                            theta2ofS = np.arccos( (q/(2*(1-q)*S2)) * ( -(J**2-L**2-S**2)/L + 2*chieff/(1+q) ) )
+                            # Eq A5
+                            deltaphiofS = np.arccos( ( S**2-S1**2-S2**2 - 2*S1*S2*np.cos(theta1ofS)*np.cos(theta2ofS) ) / (2*S1*S2*np.sin(theta1ofS)*np.sin(theta2ofS)) )
+                            # Eq A6 (prefactor cancels out)
+                            dSdtofS = np.sin(theta1ofS)*np.sin(theta2ofS)*np.sin(deltaphiofS)/S
+                            return 1/dSdtofS
+                        denominator = scipy.integrate.quad(integrand_denominator, Sminus, Splus)[0]
+                        return numerator/denominator
+                    chipavg = chip_averaged(q,chi1,chi2,theta1,theta2,deltaphi,fref=fref)
+                except ZeroDivisionError:
+                    chipavg = self.extract_param('chi_p')
+            return chipavg    
         if p == 'LambdaTilde':
             Lt, dLt   = tidal_lambda_tilde(self.m1, self.m2, self.lambda1, self.lambda2)
             return Lt

--- a/MonteCarloMarginalizeCode/Code/RIFT/lalsimutils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/lalsimutils.py
@@ -4508,7 +4508,8 @@ def DataRollTime(ht,DeltaT):  # ONLY FOR TIME DOMAIN. ACTS IN PLACE
     return DataRollBins(ht, nL)            
 
 
-def convert_waveform_coordinates(x_in,coord_names=['mc', 'eta'],low_level_coord_names=['m1','m2'],enforce_kerr=False,source_redshift=0):
+def convert_waveform_coordinates(x_in,coord_names=['mc', 'eta'],
+				 =['m1','m2'],enforce_kerr=False,source_redshift=0):
     """
     A wrapper for ChooseWaveformParams() 's coordinate tools (extract_param, assign_param) providing array-formatted coordinate changes.  BE VERY CAREFUL, because coordinates may be defined inconsistently (e.g., holding different variables constant: M and eta, or mc and q).  Note that if ChooseWaveformParam structuers are built ,the loops can be quite slow
 
@@ -4710,7 +4711,8 @@ def convert_waveform_coordinates(x_in,coord_names=['mc', 'eta'],low_level_coord_
     # note NO MASS CONVERSION here, because the fit is in solar mass units!
     for indx_out  in np.arange(len(x_in)):
         for indx in np.arange(len(low_level_coord_names)):
-            P.assign_param( low_level_coord_names[indx], x_in[indx_out,indx])
+		if low_level_coord_names[indx] != 'chi_pavg':
+			P.assign_param( low_level_coord_names[indx], x_in[indx_out,indx])            
         # Apply redshift: assume input is source-frame mass, convert m1 -> m1(1+z) = m1_z, as fit used detector frame
         P.m1 = P.m1*(1+source_redshift)
         P.m2 = P.m2*(1+source_redshift)

--- a/MonteCarloMarginalizeCode/Code/bin/util_ConstructIntrinsicPosterior_GenericCoordinates.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_ConstructIntrinsicPosterior_GenericCoordinates.py
@@ -320,6 +320,7 @@ parser.add_argument("--internal-correlate-parameters",default=None,type=str,help
 parser.add_argument("--internal-n-comp",default=1,type=int,help="number of components to use for GMM sampling. Default is 1, because we expect a unimodal posterior in well-adapted coordinates.  If you have crappy coordinates, use more")
 parser.add_argument("--internal-gmm-memory-chisquared-factor",default=None,type=float,help="Multiple of the number of degrees of freedom to save. 5 is a part in 10^6, 4 is 10^{-4}, and None keeps all up to lnL_offset.  Note that low-weight points can contribute notably to n_eff, and it can be dangerous to assume a simple chisquared likelihood!  Provided in case we need very long runs")
 parser.add_argument("--use-eccentricity", action="store_true")
+parser.add_argument("--tripwire-fraction",default=0.05,type=float,help="Fraction of nmax of iterations after which n_eff needs to be greater than 1+epsilon for a small number epsilon")
 
 # FIXME hacky options added by me (Liz) to try to get my capstone project to work.
 # I needed a way to fix the component masses and nothing else seemed to work.
@@ -2114,7 +2115,7 @@ extra_args.update({
     "n_adapt": 100, # Number of chunks to allow adaption over
     "history_mult": 10, # Multiplier on 'n' - number of samples to estimate marginalized 1D histograms with, 
     "force_no_adapt":opts.force_no_adapt,
-    "tripwire_fraction":0.05
+    "tripwire_fraction":opts.tripwire_fraction
 })
 tempering_adapt=True
 if opts.force_no_adapt:   

--- a/MonteCarloMarginalizeCode/Code/bin/util_ConstructIntrinsicPosterior_GenericCoordinates.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_ConstructIntrinsicPosterior_GenericCoordinates.py
@@ -2053,12 +2053,22 @@ if len(low_level_coord_names) ==9:
             return np.exp(my_fit([x,y,z,a,b,c,d,e,f]))
         else:
             return np.exp(my_fit(convert_coords(np.c_[x,y,z,a,b,c,d,e,f])))
+    def log_likelihood_function(x,y,z,a,b,c,d,e,f):
+        if isinstance(x,float):
+            return my_fit([x,y,z,a,b,c,d,e,f])
+        else:
+            return my_fit([convert_coords(np.c_[x,y,z,a,v,c,d,e,f]))
 if len(low_level_coord_names) ==10:
     def likelihood_function(x,y,z,a,b,c,d,e,f,g):  
         if isinstance(x,float):
             return np.exp(my_fit([x,y,z,a,b,c,d,e,f,g]))
         else:
             return np.exp(my_fit(convert_coords(np.c_[x,y,z,a,b,c,d,e,f,g])))
+    def log_likelihood_function(x,y,z,a,b,c,d,e,f,g):
+        if isinstance(x,float):
+            return my_fit([x,y,z,a,b,c,d,e,f,g])
+        else:
+            return my_fit(convert_coords(np.c_[x,y,z,a,b,c,d,e,f,g]))
 
 
 n_step = int(opts.n_chunk)

--- a/MonteCarloMarginalizeCode/Code/bin/util_ConstructIntrinsicPosterior_GenericCoordinates.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_ConstructIntrinsicPosterior_GenericCoordinates.py
@@ -527,6 +527,8 @@ coord_names = opts.parameter # Used  in fit
 if coord_names is None:
     coord_names = []
 low_level_coord_names = coord_names # Used for Monte Carlo
+if 'chi_pavg' in coord_names:
+    low_level_coord_names += ['chi_pavg']
 if opts.parameter_implied:
     coord_names = coord_names+opts.parameter_implied
 if opts.parameter_nofit:
@@ -670,6 +672,9 @@ def tapered_magnitude_prior_alt(x,loc=0.8,kappa=20.):   #
 def eccentricity_prior(x):
     return np.ones(x.shape) / (ECC_MAX-ECC_MIN) # uniform over the interval [0.0, ECC_MAX]
 
+def precession_prior(x):
+    return 0.5*np.ones(x.shape) # uniform over the interval [0.0, 2.0]
+
 def unnormalized_uniform_prior(x):
     return np.ones(x.shape)
 def unnormalized_log_prior(x):
@@ -700,6 +705,7 @@ prior_map  = { "mtot": M_prior, "q":q_prior, "s1z":s_component_uniform_prior, "s
     'phi1':mcsampler.uniform_samp_phase,
     'phi2':mcsampler.uniform_samp_phase,
     'eccentricity':eccentricity_prior,
+    'chi_pavg':precession_prior,
     'mu1': unnormalized_log_prior,
     'mu2': unnormalized_uniform_prior
 }
@@ -717,6 +723,7 @@ prior_range_map = {"mtot": [1, 300], "q":[0.01,1], "s1z":[-0.999*chi_max,0.999*c
   'lambda_plus':[0.01,lambda_plus_max],
   'lambda_minus':[-lambda_max,lambda_max],  # will include the true region always...lots of overcoverage for small lambda, but adaptation will save us.
   'eccentricity':[ECC_MIN, ECC_MAX],
+  'chi_pavg':[0.0,2.0],  
   # strongly recommend you do NOT use these as parameters!  Only to insure backward compatibility with LI results
   'LambdaTilde':[0.01,5000],
   'DeltaLambdaTilde':[-500,500],
@@ -990,12 +997,12 @@ def fit_gp(x,y,x0=None,symmetry_list=None,y_errors=None,hypercube_rescale=False,
     length_scale_bounds_est = []
     for indx in np.arange(len(x[0])):
         # These length scales have been tuned by expereience
-        length_scale_est.append( 2*np.std(x[:,indx])  )  # auto-select range based on sampling retained
-        length_scale_min_here= np.max([1e-3,0.2*np.std(x[:,indx]/np.sqrt(len(x)))])
+        length_scale_est.append( 2*np.nanstd(x[:,indx])  )  # auto-select range based on sampling retained
+        length_scale_min_here= np.max([1e-3,0.2*np.nanstd(x[:,indx]/np.sqrt(len(x)))])
         if indx == mc_index:
-            length_scale_min_here= 0.2*np.std(x[:,indx]/np.sqrt(len(x)))
-            print(" Setting mc range: retained point range is ", np.std(x[:,indx]), " and target min is ", length_scale_min_here)
-        length_scale_bounds_est.append( (length_scale_min_here , 5*np.std(x[:,indx])   ) )  # auto-select range based on sampling *RETAINED* (i.e., passing cut).  Note that for the coordinates I usually use, it would be nonsensical to make the range in coordinate too small, as can occasionally happens
+            length_scale_min_here= 0.2*np.nanstd(x[:,indx]/np.sqrt(len(x)))
+            print(" Setting mc range: retained point range is ", np.nanstd(x[:,indx]), " and target min is ", length_scale_min_here)
+        length_scale_bounds_est.append( (length_scale_min_here , 5*np.nanstd(x[:,indx])   ) )  # auto-select range based on sampling *RETAINED* (i.e., passing cut).  Note that for the coordinates I usually use, it would be nonsensical to make the range in coordinate too small, as can occasionally happens
 
     print(" GP: Input sample size ", len(x), len(y))
     print(" GP: Estimated length scales ")
@@ -1457,8 +1464,13 @@ for line in dat:
 
     # INPUT GRID: Evaluate binary parameters on fitting coordinates
     line_out = np.zeros(len(coord_names)+2)
+    chi_pavg_out = 0 #initialize
     for x in np.arange(len(coord_names)):
-        line_out[x] = P.extract_param(coord_names[x])
+        if coord_names[x] == 'chi_pavg':
+            chi_pavg_out = P.extract_param('chi_pavg')
+            line_out[x] = chi_pavg_out
+        else:
+            line_out[x] = P.extract_param(coord_names[x])
  #        line_out[x] = getattr(P, coord_names[x])
     line_out[-2] = line[col_lnL]
     line_out[-1] = line[col_lnL+1]  # adjoin error estimate
@@ -1477,7 +1489,10 @@ for line in dat:
         fac = 1
         if low_level_coord_names[x] in ['mc','m1','m2','mtot']:
             fac = lal.MSUN_SI
-        line_out[x] = P.extract_param(low_level_coord_names[x])/fac
+        if low_level_coord_names[x] == 'chi_pavg':
+            line_out[x] = chi_pavg_out
+        else:
+            line_out[x] = P.extract_param(low_level_coord_names[x])/fac
         if low_level_coord_names[x] in ['mc']:
             mc_index = x
     dat_out_low_level_coord_names.append(line_out)
@@ -1896,9 +1911,9 @@ if opts.sampler_method == "GMM":
 ##
 for p in low_level_coord_names:
     if not(opts.parameter_implied is None):
-       if p in opts.parameter_implied:
-        # We do not need to sample parameters that are implied by other parameters, so we can overparameterize 
-        continue
+       if p in opts.parameter_implied and not(p == 'chi_pavg'):
+           # We do not need to sample parameters that are implied by other parameters, so we can overparameterize 
+           continue
     prior_here = prior_map[p]
     range_here = prior_range_map[p]
 
@@ -2565,6 +2580,8 @@ for indx_here in indx_list:
             coord_to_assign = low_level_coord_names[indx]
             if coord_to_assign == 'xi':
                 coord_to_assign= 'chieff_aligned'
+            if coord_to_assign == 'chi_pavg':
+                continue # skipping chi_pavg
             Pgrid.assign_param(coord_to_assign, line[indx]*fac)
 #            print indx_here, coord_to_assign, line[indx]
         # Test for downselect


### PR DESCRIPTION
Changes:

Updates to both lalsimutils and CIP to allow use of chi_pavg as --parameter-implied

Update to CIP to include log_likelihood_function in the 9,10 parameter cases.

Update to CIP to add tripwire-fraction as an option.

Note: The line ending issue was avoided by doing the following:
1. stop git from auto-converting between CRLF and LF with: git config --global core.autocrlf false
2. using emacs as the text editor, which preserves existing line endings. Other text editors line nano try to normalize all line endings.