### PR TITLE
Bug fix for `samples_utils.py`

### DIFF
--- a/MonteCarloMarginalizeCode/Code/RIFT/misc/samples_utils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/misc/samples_utils.py
@@ -208,13 +208,18 @@ def standard_expand_samples(samples):
         samples = add_field(samples, [('chi1_perp',float)]); samples['chi1_perp'] = chi1_perp
         samples = add_field(samples, [('chi2_perp',float)]); samples['chi2_perp'] = chi2_perp
 
-        if not('phi1' in samples.dtype.names):
-            phi1 = np.arctan2(samples['a1x'], samples['a1y']);
-            phi2 = np.arctan2(samples['a2x'], samples['a2y']);
-            samples = add_field(samples, [('phi1',float), ('phi2',float), ('phi12',float)])
-            samples['phi1'] = phi1
-            samples['phi2'] = phi2
-            samples['phi12'] = phi2 - phi1
+        # Askold: this part will check if phi1, phi2, phi12 are present. If not, compute and add the missing ones
+        phi_fields = ['phi1', 'phi2', 'phi12']
+        phi_func_dict = {
+            'phi1': lambda samples: np.arctan2(samples['a1x'], samples['a1y']),
+            'phi2': lambda samples: np.arctan2(samples['a2x'], samples['a2y']),
+            'phi12': lambda samples: samples['phi2'] - samples['phi1']
+        }
+
+        for field_name in phi_fields:
+            if not (field_name in samples.dtype.names):
+                samples = add_field(samples, [(field_name, float)])
+                samples[field_name] = phi_func_dict[field_name](samples)
 
     if 'lambda1' in samples.dtype.names and not ('lambdat' in samples.dtype.names):
         Lt,dLt = lalsimutils.tidal_lambda_tilde(samples['m1'], samples['m2'],  samples['lambda1'], samples['lambda2'])


### PR DESCRIPTION
The previous version of `samples_utils,py` only checked for `phi1` field in the input `.dat` file, and tried to add `phi2`, or `phi12` even if they were present before. That caused an error if they were present. 
Modified the code so now it checks for `phi1`, `phi2` and `phi12` in the input `.dat` file and computes and adds the missing ones.