### PR TITLE
Tabular EOS project - bugfix for SUBDAG creation

### DIFF
--- a/MonteCarloMarginalizeCode/Code/bin/create_event_parameter_pipeline_BasicIteration
+++ b/MonteCarloMarginalizeCode/Code/bin/create_event_parameter_pipeline_BasicIteration
@@ -1376,7 +1376,7 @@ for it in np.arange(it_start,opts.n_iterations):
         if opts.request_gpu_ILE:
             cmd += " --request-gpu-ILE "  # DAG writer needs to make appropririate requests
         if opts.use_tabular_eos_file:
-            cmd += " --use-tabular-eos-file {} ".format(opts.use_tabular_eos_file)
+            cmd += " --use-tabular-eos-file "
         if opts.ile_retries:
             cmd += " --ile-retries {} ".format(opts.ile_retries)
         if opts.general_retries:


### PR DESCRIPTION
There was a bug in `create_event_parameter_pipeline_BasicIteration` which caused an error and the SUBDAG directory didn't have anything except `arg_lists`