### PR TITLE
`EOSManager.py` update to load EOS Tables and interpolate them if requested + minor bug fixes

### DIFF
--- a/MonteCarloMarginalizeCode/Code/bin/plot_posterior_corner.py
+++ b/MonteCarloMarginalizeCode/Code/bin/plot_posterior_corner.py
@@ -460,7 +460,7 @@ field_names=("indx","m1", "m2",  "a1x", "a1y", "a1z", "a2x", "a2y", "a2z","lnL",
 if opts.flag_tides_in_composite:
     if opts.flag_eos_index_in_composite:
         print(" Reading composite file, assumingtide/eos-index-based format ")
-        field_names=("indx","m1", "m2",  "a1x", "a1y", "a1z", "a2x", "a2y", "a2z","lambda1", "lambda2", "eos_table_index","lnL", "sigmaOverL", "ntot", "neff")
+        field_names=("indx","m1", "m2",  "a1x", "a1y", "a1z", "a2x", "a2y", "a2z","lambda1", "lambda2", "eos_indx","lnL", "sigmaOverL", "ntot", "neff")
     else:
         print(" Reading composite file, assuming tide-based format ")
         field_names=("indx","m1", "m2",  "a1x", "a1y", "a1z", "a2x", "a2y", "a2z","lambda1", "lambda2", "lnL", "sigmaOverL", "ntot", "neff")

--- a/MonteCarloMarginalizeCode/Code/bin/util_ConstructIntrinsicPosterior_GenericCoordinates.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_ConstructIntrinsicPosterior_GenericCoordinates.py
@@ -1763,7 +1763,7 @@ if opts.tabular_eos_file:
     if mc_ref > 1e10:
         mc_ref = mc_ref/lal.MSUN_SI
     m_ref = mc_ref*np.power(2, 1./5.)   # assume equal mass
-    my_eos_sequence = EOSManager.EOSSequenceLandry(fname=opts.tabular_eos_file,load_ns=True,oned_order_name='Lambda', oned_order_mass=m_ref)
+    my_eos_sequence = EOSManager.EOSSequenceLandry(fname=opts.tabular_eos_file, load_ns=True, oned_order_name='Lambda', oned_order_mass=m_ref, no_sort = False)
 
     # Define prior, NOT NORMALIZED
     prior_map['ordering'] =lambda x: np.ones(x.shape)


### PR DESCRIPTION
* `EOSManager.py`  - when initializing class `EOSSequenceLandry` if `load_eos = True` the code will now load EOS tables in the same format as TOV tables (`load_ns = True`). These will NOT be interpolated yet
* `EOSManager.py` - added a function `EOSSequenceLandry.interpolate_eos_tables`. Allows the user to choose the interpolation base and number of points. Simple interpolation in log space is implemented now, more complicated and precise interpolators can be added in the future.
* `util_ConstructIntrinsicPosterior_GenericCoordinates.py` - if a tabular EOS file is used, `EOSSequenceLandry` will be initialized with sorting (`no_sort = False`). This fix is necessary for proper PE in EOS parameter space
* `plot_posterior_corner.py` - minor bug fix that makes it possible to plot `eos_indx` grey points on the standard RIFT corner plots