### PR TITLE
Tabular EOS project: Plotting Utilities and a script for making the plots + typo fix

### DIFF
--- a/MonteCarloMarginalizeCode/Code/RIFT/plot_utilities/TabularEOSPlotUtilities.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/plot_utilities/TabularEOSPlotUtilities.py
@@ -1,0 +1,617 @@
+# Author: Askold Vilkha (https://github.com/askoldvilkha), av7683@rit.edu, askoldvilkha@gmail.com
+
+# This code is a library of functions for plotting tabular EOS data along with the EOS inference from posterior samples obtained using the RIFT code.
+# Current functionality includes:
+# 1. Pressure vs Density plots
+# 2. Mass vs Radius plots
+
+# Possible future functionality:
+# 1. Radius and Tidal deformability (LambdaTilde) histograms at a given mass (1.4 Msun by default)
+# 2. Pressure vs Energy density plots
+# 3. Pressure vs Density plots in the SI units
+
+import numpy as np
+import matplotlib.pyplot as plt
+import h5py
+import RIFT.physics.EOSManager as EOSManager
+from natsort import natsorted
+import warnings
+
+def EOS_data_loader(tabular_eos_file: str, data_label: str = None, verbose: bool = False) -> dict:
+    """
+    Load tabular EOS data from a HDF5 file.
+
+    Parameters
+    ----------
+    tabular_eos_file : str
+        The path to the tabular EOS file. The file should be in the .h5 format.
+        The function will automatically get the data label from the file if the format is 'LCEHL_EOS_posterior_samples_<data_label>.h5'.
+    data_label : str, optional
+        The label of the tabular EOS data that is loaded. If not provided the label will be generated from the file name automatically.
+    verbose : bool, optional
+        If True, the function will print information about the progress.
+
+    Returns
+    -------
+    EOS_data : dict
+        A dictionary containing the necessary tabular EOS data for plotting functions.
+        The dictionary contains the following keys:
+        - 'eos_tables': the tabular EOS data (interpolated by default)
+        - 'tov_tables': the TOV data (not interpolated)
+        - 'eos_names': the names of the EOS tables
+        - 'data_label': the label of the tabular EOS data
+    """
+
+    # load tabular EOS data
+    EOSManager_Local = EOSManager.EOSSequenceLandry(fname = tabular_eos_file, load_ns = True, load_eos = True, verbose = verbose, eos_tables_units = 'cgs')
+    eos_tables = EOSManager_Local.interpolate_eos_tables('baryon_density')
+    tov_tables = EOSManager_Local.eos_ns_tov
+    eos_names = EOSManager_Local.eos_names
+
+    if verbose:
+        print(f"Loaded tabular EOS data from the file: {tabular_eos_file}")
+    EOS_data = {'eos_tables': eos_tables, 'tov_tables': tov_tables, 'eos_names': eos_names}
+
+    if data_label is None:
+        data_label = tabular_eos_file.split('_')[-1].split('.')[0]
+        
+    if data_label.upper() not in ['PSR', 'PSR+GW', 'PSR+GW+NICER']:
+        warnings.warn(f"Data label for the tabular EOS file is not one of the commonly used: {data_label}. Please make sure the data label is correct.")
+    
+    EOS_data['data_label'] = data_label
+
+    if verbose:
+        print(f'Loaded tabular EOS data from {tabular_eos_file} with data label: {data_label}')
+
+    return EOS_data
+
+def posterior_data_loader(posterior_file: str, data_label: str = None, verbose: bool = False, out_all: bool = False) -> dict:
+    """
+    Load the posterior data from a .dat file
+
+    Parameters
+    ----------
+    posterior_file : str
+        The path to the posterior samples file. The file should be in the .dat format.
+        The function will automatically get the data label from the file if the format is 'posterior_samples_<data_label>.dat'.
+    data_label : str
+        The label of the data. If not provided, the function will try to get it from the file name.
+    verbose : bool
+        If True, the function will print information about the progress.
+    out_all : bool
+        If True, the function will return all the posterior samples. If False, the function will return only the EOS indices posteriors.
+
+    Returns
+    -------
+    posterior_data : dict
+        A dictionary containing the posterior samples.
+        The dictionary contains the following keys:
+        - 'posterior_samples_eos' : The posterior samples for the EOS indices.
+        - 'data_label' : The label of the data.
+        - 'posterior_samples_all' : The posterior samples for all the parameters. (Only if `out_all` is True)
+
+    """
+
+    # load the posterior samples
+    posterior_samples = np.genfromtxt(posterior_file, names = True, replace_space = None)
+    posterior_samples_eos = posterior_samples['eos_indx']
+    posterior_data = {'posterior_samples_eos': posterior_samples_eos, 'data_label': data_label}
+    if out_all:
+        posterior_data['posterior_samples_all'] = posterior_samples
+
+    if data_label is None:
+        data_label = posterior_file.split('_')[-1].split('.')[0]
+        posterior_data['data_label'] = data_label
+    if data_label.upper() not in ['PSR', 'PSR+GW', 'PSR+GW+NICER']:
+        warnings.warn(f"Data label for the posterior samples file is not one of the commonly used: {data_label}. Please make sure the data label is correct.")
+    
+    if verbose:
+        print(f'Posterior samples loaded successfully from {posterior_file} with data label: {data_label}')
+    
+    return posterior_data
+
+def link_eos_data_to_posterior(eos_data: dict, plot_type: str, posterior_data: dict = None) -> dict:
+    """
+    This function links the EOS data to the posterior data and outputs a dictionary with the linked data suited for the corresponding plot type.
+
+    Parameters
+    ----------
+    eos_data : dict
+        Dictionary containing the EOS data. Should be generated using the function EOS_data_loader. 
+        See TabularEOSPlotUtilities.EOS_data_loader for more information on the format of the dictionary.
+    plot_type : str
+       String specifying the type of plot to be generated. Currently supported options are: 'pressure_density' and 'mass_radius'.
+    posterior_data : dict
+        Dictionary containing the posterior data. Should be generated using the function posterior_data_loader. 
+        See TabularEOSPlotUtilities.posterior_data_loader for more information on the format of the dictionary.
+        If posterior_data is not provided, the function will generate prior data from the EOS data.
+    
+    Returns
+    -------
+    plot_data_gen_dict: dict
+        Dictionary containing the linked EOS and posterior data suited for the corresponding plot type.
+        The format will fit the input requirements of the plotting functions in TabularEOSPlotUtilities.
+    """
+    # check if the plot type is supported
+    if plot_type.lower() not in ['pressure_density', 'mass_radius']:
+        raise ValueError('The plot type is not supported. Currently supported options are: "pressure_density" and "mass_radius".')
+    
+    # generate the dictionary to store the linked data
+    plot_data_gen_dict = {}
+    # generate input data for the pressure_density plot
+    if plot_type.lower() == 'pressure_density':
+        plot_data_gen_dict['eos_tables'] = eos_data['eos_tables']
+
+    # generate input data for the mass_radius plot
+    elif plot_type.lower() == 'mass_radius':
+        plot_data_gen_dict['tov_tables'] = eos_data['tov_tables']
+    
+    plot_data_gen_dict['eos_names'] = eos_data['eos_names']
+
+    # if the posterior data is provided, link the posterior data to the EOS data, if not, generate prior data
+    if posterior_data is not None:
+        plot_data_gen_dict['data_label'] = posterior_data['data_label']
+        plot_data_gen_dict['posteriors_eos'] = posterior_data['posterior_samples_eos']
+        plot_data_gen_dict['posterior'] = True
+    else:
+        plot_data_gen_dict['data_label'] = eos_data['data_label']
+        plot_data_gen_dict['posteriors_eos'] = np.arange(len(eos_data['eos_names']))
+        plot_data_gen_dict['posterior'] = False
+    
+    return plot_data_gen_dict
+
+def generate_posterior_eos_param_grid(posteriors_eos: np.ndarray, eos_tables: dict, eos_names: list, param: str = 'pressure', verbose: bool = False) -> np.ndarray:
+    """
+    This function generates a grid of the format (N, M), 
+    where N is the number of points in the EOS table, and M is the number of posterior samples.
+    Each column of the grid will be the EOS table for a given posterior sample. 
+    Each row will be the values of the parameter of interest (e.g. pressure, energy density, etc.) 
+    for a given point of the parameter used as the x-axis of the plot (and the interpolation base) respectively.
+    By default, the parameter of interest is the pressure and the interpolation base is the baryon density.
+    Thus, each row of the grid will correspond to the pressure values at each posterior sample for a given baryon density value.
+
+    Parameters
+    ----------
+    posteriors_eos : np.ndarray
+        Array of EOS table indices for each posterior sample. Should be the 'eos_indx' column of the posterior samples.
+    eos_tables : dict
+        Dictionary of EOS tables. The keys should be the EOS names and the values should be the EOS tables.
+        Should be generated using the EOSManager.interpolate_eos_tables() method.
+        IMPORTANT! The EOS parameter used as the x-axis of the plot should be the same for all EOS tables.
+        If this is not true, the percentiles will not make any sense!
+    eos_names : list
+        List of EOS names. Should be generated using the EOSManager.eos_names attribute.
+    param : str, optional
+        Parameter of interest. The default is 'pressure'. Another options are 'energy_density' and 'baryon_density'.
+    verbose : bool, optional
+        If True, print the progress of the function. The default is False.
+
+    Returns
+    -------
+    posteriors_eos_param_grid : np.ndarray
+        Grid of the format (N, M) where N is the number of points in the EOS table and M is the number of posterior samples.
+    
+    Raises
+    ------
+    ValueError
+        If the parameter of interest is not present in the EOS tables.
+    ValueError
+        If the number of points in the EOS table for any EOS is different from the number of points in the EOS tables for other EOSs.
+        
+    """
+
+    if param not in eos_tables[eos_names[0]].keys():
+        raise ValueError(f'The parameter {param} is not present in the EOS tables! Please choose one of the following parameters: {eos_tables[eos_names[0]].keys()} If the parameters listed are other than "pressure, energy_density, baryon_density", please double-check the EOS tables!')
+
+    # get the number of points in the EOS table (N) and the number of posterior samples (M)
+    N = len(eos_tables[eos_names[0]][param])
+    M = len(posteriors_eos)
+    if verbose:
+        print(f'The EOS parameter grid will have {N} points and there are {M} posterior samples.')
+
+    # initialize the grid
+    posteriors_eos_param_grid = np.zeros((N, M))
+
+    # fill the grid
+    for i, eos_indx in enumerate(posteriors_eos):
+        if verbose:
+            print(f'Processing posterior sample {i} with EOS index {int(eos_indx)}')
+        eos_name = eos_names[int(eos_indx)]
+        eos_table = eos_tables[eos_name]
+        N_i = len(eos_table[param])
+        if N_i != N:
+            raise ValueError(f'The number of points in the EOS table for {eos_name} is different from the number of points in the EOS tables for other EOSs! Please interpolate the tables before passing them to this function!')
+        posteriors_eos_param_grid[:, i] = eos_table[param]
+    
+    if verbose:
+        print('The EOS parameter grid has been successfully generated!')
+    
+    return posteriors_eos_param_grid
+
+def pressure_density_plot_data_gen(eos_tables: dict, posteriors_eos: np.ndarray, eos_names: list, data_label: str, posterior: bool = True, perc_values: list = [5, 95], custom_color: str = None, use_energy_dens: bool = False) -> dict:
+    """
+    This function generates the data dictionary for the pressure-density plot. 
+    It is designed as an auxiliary function for the pressure_density_plot() function, and should be used as input for that function. 
+
+    The dictionary will contain the following keys:
+    - 'x_dens_grid': the grid of baryon densities for the x-axis
+    - 'y_pres_perc': percentiles of the pressure for each baryon density. 
+    This will be a np.ndarray of shape (2, N), where N is the number of points in the EOS table.
+    - 'posterior': True if the data is for the posterior samples, False if it is for the prior samples.
+    - 'perc_values': the percentiles used. Default is [5, 95].
+    - 'data_label': the label for the data (e.g. 'PSR+GW+NICER', 'PSR', etc.)
+    - 'custom_color': the color for the plot. If None, the color will be chosen automatically.
+
+    The function will return the data dictionary.
+
+    Parameters
+    ----------
+    eos_tables : dict
+        The dictionary of EOS tables. Should be generated using the EOSManager.interpolate_eos_tables() method.
+    posteriors_eos : np.ndarray
+        The array of posterior samples. Should be the 'eos_indx' column from the posterior samples file. 
+        If the user wants to generate the data for the prior samples, np.arange(int(len(eos_names))) should be used.
+    eos_names : list
+        The list of EOS names. Should be generated using the EOSManager.eos_names attribute.
+    data_label : str
+        The label for the data (e.g. 'PSR+GW+NICER', 'PSR', etc.). There are no restrictions on this parameter.
+    posterior : bool, optional
+        True if the data is for the posterior samples, False if it is for the prior samples. Default is True.
+    perc_values : list, optional
+        The percentiles used. Default is [5, 95]. 
+        NOTE! These are percentile values, not quantile values. Should be in the range [0, 100]. 
+        The code will raise warning if the values are in [0, 1] range, but will still run, please be aware of this.
+    custom_color : str, optional
+        The color for the plot. If None, the color will be chosen automatically. Default is None.
+    use_energy_dens : bool, optional
+        If True, the energy density will be used as the x-axis parameter instead of the baryon density. Default is False.
+    
+    Returns
+    -------
+    density_pressure_data : dict
+        The dictionary with the data for the pressure-density plot.
+    """
+
+    # generate the grid of pressure values based on the posterior samples
+    posteriors_eos_pressure_grid = generate_posterior_eos_param_grid(posteriors_eos, eos_tables, eos_names, 'pressure')
+
+    # calculate the percentiles of the pressure for each baryon density
+    pressure_percentiles = np.percentile(posteriors_eos_pressure_grid, perc_values, axis = 1)
+
+    # collect and fill the data in the dictionary
+    density_pressure_data = {}
+
+    if use_energy_dens:
+        raise NotImplementedError('The energy density is not yet implemented as the x-axis parameter! Please use the baryon density instead.')
+    else:
+        density_pressure_data['x_dens_grid'] = eos_tables[eos_names[0]]['baryon_density']
+    density_pressure_data['y_pres_perc'] = pressure_percentiles
+    density_pressure_data['posterior'] = posterior
+    density_pressure_data['perc_values'] = perc_values
+    density_pressure_data['data_label'] = data_label
+    if custom_color is not None:
+        density_pressure_data['custom_color'] = custom_color
+    
+    return density_pressure_data
+
+def pressure_density_plot(*density_pressure_data: dict, use_energy_dens: bool = False, units: str = 'cgs', xlim: tuple = (1e14, 1e16), ylim: tuple = (1e32, 1e38), title: str = None):
+    """
+    This function generates a plot of pressure vs. baryon density for the given EOS data.
+
+    Parameters
+    ----------
+    density_pressure_data : dict
+        A dictionary with the following structure:
+
+            {'x_dens_grid': np.ndarray,
+             'y_pres_perc': np.ndarray,
+             'posterior': bool,
+             'perc_values': list,
+             'data_label': str,
+             'custom_color': str}
+
+            `x_dens_grid`: np.ndarray - grid of baryon densities. 
+            If the EOS tables were interpolated, one can use the `baryon_density` column of any EOS table (`eos_tables['eos_0']['baryon_density']`); 
+
+            `y_pres_perc`: np.ndarray - percentiles of pressure values for each density point.
+            IMPORTANT! Make sure that the percentiles were calculated of the pressure grids interpolated over the same `x_dens_grid` values.
+            Must be of the format (2, N), where N is the number of points in the `x_dens_grid`.
+            `y_pres_perc[0, :]` is the lower percentile, `y_pres_perc[1, :]` is the upper percentile.
+
+            `posterior`: bool - if True, the data is considered to be posterior samples. If False, the data is considered to be prior samples.
+
+            `perc_values`: list of 2 percentiles corresponding to the `y_pres_perc` array. If none is provided, the default values are [5, 95].
+
+            `data_label`: str - label for the data used, i. e. 'PSR+GW+NICER', 'PSR+GW', etc.
+
+            `custom_color`: color for the percentiles provided in this data entry. If none is provided, the default colormap is used.
+    energy_dens_bool : bool
+        If you are using energy density instead of baryon density, set this to True. Default is False.
+    units : str
+        Units of the data. Default is 'cgs'.
+    xlim : tuple
+        X-axis limits. Default is (1e14, 1e16). Corresponds the the CGS units.
+    ylim : tuple
+        Y-axis limits. Default is (1e32, 1e38). Corresponds the the CGS units.
+    title: str
+        Title of the plot. Default is None. If no title has been provided, the title will be set to generic Pressure vs Baryon Density. 
+    
+    Returns
+    -------
+    None
+    """
+    if use_energy_dens:
+        raise NotImplementedError('The energy density is not yet implemented as the x-axis parameter! Please use the baryon density instead.')
+        # warnings.warn('The energy density as the x-axis parameter is not fully tested yet! Please be cautious of that when analyzing the resulting plots.')
+
+    colors_def = plt.cm.get_cmap('tab10')
+    density_units = {'cgs': 'g/cm$^3$', 'SI': 'kg/m$^3$'}
+    pressure_units = {'cgs': 'dyn/cm$^2$', 'SI': 'N/m$^2$'}
+
+    fig, ax = plt.subplots()
+    for i, data in enumerate(density_pressure_data):
+        x_dens_grid = data['x_dens_grid']
+        y_pres_perc = data['y_pres_perc']
+        posterior = data['posterior']
+        data_label = data['data_label']
+
+        try: 
+            perc_values = data['perc_values']
+        except KeyError:
+            perc_values = [5, 95]
+        try: 
+            colors = data['custom_color']
+        except KeyError:
+            colors = colors_def(i)
+
+        if posterior:
+            # posteriors
+            ax.loglog(x_dens_grid, y_pres_perc[0], color = colors, label = f'{data_label} posterior {perc_values[1] - perc_values[0]}% CI')
+            ax.loglog(x_dens_grid, y_pres_perc[1], color = colors)
+            ax.fill_between(x_dens_grid, y_pres_perc[0], y_pres_perc[1], color = colors, alpha = 0.3)
+        else:
+            # priors
+            ax.loglog(x_dens_grid, y_pres_perc[0], color = colors, linestyle = '--', label = f'{data_label} {perc_values[1] - perc_values[0]}% CI')
+            ax.loglog(x_dens_grid, y_pres_perc[1], color = colors, linestyle = '--')
+            ax.fill_between(x_dens_grid, y_pres_perc[0], y_pres_perc[1], color = colors, alpha = 0.3)
+
+    ax.plot((2.5e14, 2.5e14), (1e32, 1e38), color = 'black', linestyle = '--')
+    ax.text(2.5e14, 2e32, '$\\rho_{\\text{nuc}}$', ha = 'right', va = 'center', rotation = 'vertical', fontsize = 14)
+
+    ax.plot((5e14, 5e14), (1e32, 1e38), color = 'black', linestyle = '--')
+    ax.text(5e14, 2e32, '$2\\rho_{\\text{nuc}}$', ha = 'right', va = 'center', rotation = 'vertical', fontsize = 14)
+
+    ax.plot((1.5e15, 1.5e15), (1e32, 1e38), color = 'black', linestyle = '--')
+    ax.text(1.5e15, 2e32, '$6\\rho_{\\text{nuc}}$', ha = 'right', va = 'center', rotation = 'vertical', fontsize = 14)
+
+    ax.set_xscale('log')
+    ax.set_yscale('log')
+    ax.set_xlim(xlim)
+    ax.set_ylim(ylim)
+    ax.grid(True)
+    ax.set_xlabel(f'Baryon density, $\\rho$ [{density_units[units]}]', fontsize = 16)
+    ax.set_ylabel(f'Pressure, $P$ [{pressure_units[units]}]', fontsize = 16)
+    ax.legend()
+    if title is None:
+        ax.set_title('EOS Inference (Pressure vs Baryon Density)', fontsize = 16)
+        plt.savefig('Pressure_Density_plot.pdf')
+    else:
+        ax.set_title(title, fontsize = 16)
+        plt.savefig(f'{title}.pdf')
+    plt.show()
+
+    return None
+
+def tov_tables_interpolator(tov_tables: dict, m_interp_range: list = [1, 1.9], n_points: int = 500, m_extremum_breakpoint: float = 1.9, verbose: bool = False) -> dict:
+    """
+    This function interpolates inserted TOV tables and removes all the point from each table if the change in gradient occurs after a breakpoint (`m_extremum_breakpoint`).
+    This is done to prevent the double counting in percentiles.
+
+    Parameters
+    ----------
+    tov_tables : dict
+        The dictionary of TOV tables. Should be generated using the EOSManager.tov_tables attribute.
+    m_interp_range : list
+        The range of the interpolated mass values. Default is [1, 1.9].
+    n_points : int
+        The number of points in the interpolated mass values. Default is 500.
+    m_extremum_breakpoint : float
+        The breakpoint value for the extremum in the mass-radius curve. Default is 1.9.
+        The value 1.9 was established from the previous analysis of the TOV tables. 
+        Many EOS have extremums below 1 Msun, but they do not produce double M-R curves in the region 1 - 1.9 Msun.
+        EOS that have extremums above the 1.9 Msun (in our previous analysis) would often have the M-R curve that returns to the region 1 - 1.9 Msun.
+        This would cause the double counting of the R values in the percentiles. 
+        Therefore, we delete the points from the tov_tables after the extremum if it is above 1.9 Msun.
+        Only a few EOS (~20 of 10000) have extremums in the region 1 - 1.9 Msun, and their impact on the percentiles is negligible.
+        NOTE! This value may be different for different EOS tables. Please analyze your EOS tables before setting this parameter.
+        See an example of the analysis in the notebook: 
+        https://github.com/oshaughn/RIT-matters/tree/master/communications/20230613-ROSAV-TabularEOSInference/plotting/EOS_plots.ipynb
+    verbose : bool
+        If True, the function will print the progress of the interpolation. Default is False.
+    
+    Returns
+    -------
+    tov_interp_tables : dict
+        The dictionary of interpolated TOV tables.
+    """
+
+    tov_interp_tables = {}
+    # we modify the TOV tables to avoid the M-R curve double counting problem
+    if verbose:
+        print(f'Removing the points after the extremum if the extremum is above the breakpoint: {m_extremum_breakpoint} Msun')
+        
+    for name in natsorted(tov_tables.keys()):
+        # to find the extremum, we find the points where the gradient changes sign
+        grad = np.gradient(tov_tables[name]['M'])
+        grad_prods = grad[:-1] * grad[1:]
+        extremum_indx = np.where(grad_prods < 0)
+
+        # we remove the points after the extremum if the extremum is above the breakpoint
+        # NOTE! We assume the extremums before the breakpoint to not be significant for the percentiles. 
+        # Please make sure to analyze your EOS tables before setting the breakpoint value.
+        extremum_mass = tov_tables[name]['M'][extremum_indx]
+        mask = extremum_mass > m_extremum_breakpoint
+        extremum_indx = extremum_indx[0][mask]
+        if len(extremum_indx) == 0:
+            continue
+        breakpoint_extremum = extremum_indx[0]
+        tov_tables[name] = tov_tables[name][:breakpoint_extremum + 1]
+    
+    if verbose:
+        print(f'All the points after the extremum above the breakpoint are removed. Moving to the interpolation.')
+
+    # we interpolate the TOV tables
+    m_interp_base = np.linspace(m_interp_range[0], m_interp_range[1], n_points)
+    for name in natsorted(tov_tables.keys()):
+        tov_interp_tables[name] = {}
+        r_interp_vals = np.interp(m_interp_base, tov_tables[name]['M'], tov_tables[name]['R'])
+        Lambda_interp_vals_log = np.interp(m_interp_base, tov_tables[name]['M'], np.log(tov_tables[name]['Lambda']))
+        tov_interp_tables[name]['M'] = m_interp_base
+        tov_interp_tables[name]['R'] = r_interp_vals
+        tov_interp_tables[name]['Lambda'] = np.exp(Lambda_interp_vals_log)
+
+    if verbose:
+        print(f'The interpolation is completed. Returning the interpolated TOV tables.')
+
+    return tov_interp_tables
+    
+def mass_radius_plot_data_gen(tov_tables: dict, posteriors_eos: np.ndarray, eos_names: list, data_label: str, posterior: bool = True, tov_interp: bool = False, perc_values: list = [5, 95], custom_color: str = None) -> dict:
+    """
+    This function generates the data dictionary for the mass-radius plot
+
+    Parameters
+    ----------
+    tov_tables : dict
+        The dictionary of TOV tables. Should be generated using the EOSManager.tov_tables attribute.
+    posteriors_eos : np.ndarray
+        The array of posterior samples. Should be the 'eos_indx' column from the posterior samples file. 
+        If the user wants to generate the data for the prior samples, np.arange(int(len(eos_names))) should be used.
+    eos_names : list
+        The list of EOS names. Should be generated using the EOSManager.eos_names attribute.
+    data_label : str
+        The label for the data (e.g. 'PSR+GW+NICER', 'PSR', etc.). There are no restrictions on this parameter.
+    posterior : bool
+        True if the data is for the posterior samples, False if it is for the prior samples. Default is True.
+    tov_interp : bool
+        True if the inserted TOV tables are already interpolated. Default is False.
+        If False, the code will interpolate the tables using the default settings (linear interpolation, 500 points between 1 and 1.9 Msun, extremum breakpoint at 1.9 Msun).
+        See the tov_tables_interpolator() function documentation for more details.
+    perc_values : list
+        The percentiles used. Default is [5, 95]. 
+        NOTE! These are percentile values, not quantile values. Should be in the range [0, 100]. 
+        The code will raise warning if the values are in [0, 1] range, but will still run, please be aware of this.
+    custom_color : str
+        The color for the plot. If None, the color will be chosen automatically. Default is None.
+    
+    Returns
+    -------
+    mass_radius_data : dict
+        The dictionary with the data for the mass-radius plot.
+    
+    """
+
+    if not tov_interp:
+        tov_tables = tov_tables_interpolator(tov_tables)
+
+    # generate the grid of radius values based on the posterior samples
+    posteriors_eos_radius_grid = generate_posterior_eos_param_grid(posteriors_eos, tov_tables, eos_names, 'R')
+
+    # calculate the percentiles of the radius for each mass point
+    radius_percentiles = np.percentile(posteriors_eos_radius_grid, perc_values, axis = 1)
+
+    # collect and fill the data in the dictionary
+    mass_radius_data = {}
+    mass_radius_data['x_rad_perc'] = radius_percentiles
+    mass_radius_data['y_mass_grid'] = tov_tables[list(tov_tables.keys())[0]]['M']
+    mass_radius_data['posterior'] = posterior
+    mass_radius_data['perc_values'] = perc_values
+    mass_radius_data['data_label'] = data_label
+    if custom_color is not None:
+        mass_radius_data['custom_color'] = custom_color
+
+    return mass_radius_data
+
+def mass_radius_plot(*mass_radius_data: dict, xlim: tuple = (8, 17), ylim: tuple = (1, 1.9), title: str = None):
+    """
+    This function generates a plot of mass vs. radius for the given EOS data.
+
+    Parameters:
+    -----------
+    mass_radius_data : dict
+        A dictionary with the following structure:
+
+            {'x_rad_perc': np.ndarray,
+             'y_mass_grid': np.ndarray,
+             'posterior': bool,
+             'perc_values': list,
+             'data_label': str,
+             'custom_color': str}
+
+            `x_rad_perc` : np.ndarray - the percentiles of the radius for each mass point
+            IMPORTANT! Make sure that the percentiles were calculated of the radius grids interpolated over the same `y_mass_grid` values.
+            Must be of the format (2, N), where N is the number of points in the `y_mass_grid`.
+            `x_rad_perc[0, :]` is the lower percentile, `x_rad_perc[1, :]` is the upper percentile.
+
+            `y_mass_grid` : np.ndarray - the grid of mass values. 
+            If the TOV tables were interpolated, one can use the `M` values from any of the interpolated tables. (tov_interp_tables['eos_0']['M'])
+
+            `posterior` : bool - True if the data is for the posterior samples, False if it is for the prior samples.
+
+            `perc_values` : list - the percentiles used in `x_rad_perc`. Default is [5, 95].
+
+            `data_label` : str - the label for the data (e.g. 'PSR+GW+NICER', 'PSR', etc.). There are no restrictions on this parameter.
+
+            `custom_color` : color for the percentiles provided in this data entry. If none is provided, the default colormap is used.
+            
+    xlim : tuple
+        X-axis limits. Default is (8, 17). Corresponds the the km units.
+    ylim : tuple
+        Y-axis limits. Default is (1, 1.9). Corresponds the the solar mass units.
+    title: str
+        Title of the plot. Default is None. If no title has been provided, the title will be set to generic Mass vs Radius.
+    
+    Returns:
+    --------
+    None
+    """
+
+    colors_def = plt.cm.get_cmap('tab10')
+    mass_units = 'M$_\odot$'
+    radius_units = 'km'
+
+    fig, ax = plt.subplots()
+    for i, data in enumerate(mass_radius_data):
+        x_rad_perc = data['x_rad_perc']
+        y_mass_grid = data['y_mass_grid']
+        posterior = data['posterior']
+        data_label = data['data_label']
+        perc_values = data['perc_values']
+        try:
+            colors = data['custom_color']
+        except KeyError:
+            colors = colors_def(i)
+
+        if posterior:
+            # posteriors
+            ax.plot(x_rad_perc[0], y_mass_grid, color = colors, label = f'{data_label} posterior {perc_values[1] - perc_values[0]}% CI')
+            ax.plot(x_rad_perc[1], y_mass_grid, color = colors)
+            ax.fill_betweenx(y_mass_grid, x_rad_perc[0], x_rad_perc[1], color = colors, alpha = 0.3)
+        else:
+            # priors
+            ax.plot(x_rad_perc[0], y_mass_grid, color = colors, linestyle = '--', label = f'{data_label} {perc_values[1] - perc_values[0]}% CI')
+            ax.plot(x_rad_perc[1], y_mass_grid, color = colors, linestyle = '--')
+            ax.fill_betweenx(y_mass_grid, x_rad_perc[0], x_rad_perc[1], color = colors, alpha = 0.3)
+
+    ax.set_xlim(xlim)
+    ax.set_ylim(ylim)
+    ax.grid(True)
+    ax.set_xlabel(f'Radius, $R$ [{radius_units}]', fontsize = 16)
+    ax.set_ylabel(f'Mass, $M$ [{mass_units}]', fontsize = 16)
+    ax.legend()
+    if title is None:
+        ax.set_title('EOS Inference (Mass vs Radius)', fontsize = 16)
+        plt.savefig('Mass_Radius_plot.pdf')
+    else:
+        ax.set_title(title, fontsize = 16)
+        plt.savefig(f'{title}.pdf')
+    plt.show()

--- a/MonteCarloMarginalizeCode/Code/bin/plot_tabular_eos_inference.py
+++ b/MonteCarloMarginalizeCode/Code/bin/plot_tabular_eos_inference.py
@@ -1,0 +1,283 @@
+#! /usr/bin/env python
+
+# Author: Askold Vilkha (https://github.com/askoldvilkha), av7683@rit.edu, askoldvilkha@gmail.com
+
+# This script is used to plot the results of the tabular EOS inference. 
+# Minimal input is the path to the tabular EOS file and posterior samples files the user wants to have on the plot.
+# The user will have to specify which plots to make by setting the corresponding flags to True.
+# The script has a functionality to choose custom labels and colors for the posterior samples.
+# If multiple tabular EOS files are provided, the user will have to specify which ones to plot and to use for the posterior samples.
+
+import numpy as np
+import matplotlib.pyplot as plt
+import h5py
+import RIFT.physics.EOSManager as EOSManager
+from natsort import natsorted
+import warnings
+import argparse
+
+import ast
+import textwrap
+
+import RIFT.plot_utilities.TabularEOSPlotUtilities as tabplot
+
+# store long help messages in a dictionary to avoid cluttering the parser code below
+argparse_help_dict = {
+    'help': textwrap.dedent('''\
+    This script is used to plot the results of the tabular EOS inference obtained with RIFT code.
+    The user can plot pressure vs. density and mass vs. radius plots for the tabular EOS priors and posterior samples.
+    The user can specify the tabular EOS files, posterior samples files, labels, and colors for the plots.
+    The user has to provide the path to the tabular EOS files and the posterior samples files.
+    Basic usage: 
+    plot_tabular_eos_inference.py --tabular-eos-file <path_to_tabular_eos_file> --tabular-eos-label <tabular_eos_file_label> --posterior-file <path_to_posterior_samples_file> 
+    --posterior-label <posterior_samples_file_label> --plot-p-vs-rho --plot-m-vs-r --use-bgcgb-colormap'''),
+
+    'tabular-eos-file': textwrap.dedent('''\
+    Path to the tabular EOS file. If multiple files are provided only the first one will be used for EOS posteriors unless specified otherwise by the user. 
+    See --posterior-tabular-map for more information.','''),
+
+    'plot-tabular-eos-prior': textwrap.dedent('''\
+    Specify which tabular EOS files to plot priors for. 
+    Should be specified by the label of the tabular EOS file'''),
+
+    'posterior-tabular-map': textwrap.dedent('''\
+    Specify which tabular EOS file to use for the posterior samples. 
+    Should be specified by the label of the tabular EOS files and the posterior samples files. 
+    The input format should be a dictionary in the form of a string:
+    '{'tabular_eos_file_1': ['posterior_file_1', 'posterior_file_2'] 'tabular_eos_file_2': 'posterior_file_3', ...}'. 
+    Use either labels instead of the file names.''')
+}
+
+parser = argparse.ArgumentParser(description = argparse_help_dict['help'])
+
+# basic arguments
+parser.add_argument('--tabular-eos-file', action = 'append', help = argparse_help_dict['tabular-eos-file'], required = True)
+parser.add_argument('--posterior-file', action = 'append', help = 'Path to the posterior samples file. If none are provdided, only priors will be plotted.')
+parser.add_argument('--plot-p-vs-rho', action = 'store_true', help = 'Plot pressure vs. density')
+parser.add_argument('--plot-m-vs-r', action = 'store_true', help = 'Plot mass vs. radius')
+parser.add_argument('--tabular-eos-label', action = 'append', help = 'Label for the tabular EOS file')
+parser.add_argument('--posterior-label', action = 'append', help = 'Label for the posterior samples file')
+parser.add_argument('--color', action = 'append', help = 'Colors for the plot. If not provided, colors will be chosen automatically')
+parser.add_argument('--use-bgcgb-colormap', action = 'store_true', help = 'Use the BlackGreyCyanGreenBlue colormap for the plots')
+parser.add_argument('--verbose', action = 'store_true', help = 'Print information on the progress of the code')
+
+# extra arguments for more advanced plotting (plot posteriors for multiple tabular EOS files, plot tabular EOS priors, etc.)
+parser.add_argument('--plot-tabular-eos-prior', action = 'append', help = argparse_help_dict['plot-tabular-eos-prior'])
+parser.add_argument('--posterior-tabular-map', action = 'store', help = argparse_help_dict['posterior-tabular-map'])
+parser.add_argument('--plot-p-vs-rho-title', action = 'store', help = 'Title for the pressure vs. density plot')
+parser.add_argument('--plot-m-vs-r-title', action = 'store', help = 'Title for the mass vs. radius plot')
+
+args = parser.parse_args()
+
+tabular_eos_labels = [None] * len(args.tabular_eos_file)
+
+# the code can operate with less labels than files, it will use the default labels for the rest of the files
+if args.tabular_eos_label is not None:
+    if len(args.tabular_eos_label) < len(args.tabular_eos_file):
+        warnings.warn('Number of tabular EOS labels is less than the number of tabular EOS files. The code will use the default labels after the last provided label.')
+    elif len(args.tabular_eos_label) > len(args.tabular_eos_file):
+        raise ValueError('Number of tabular EOS labels is greater than the number of tabular EOS files. Please check if you have provided the correct number of labels or files.')
+
+    tabular_eos_labels[:len(args.tabular_eos_label)] = args.tabular_eos_label # fill in the provided labels, use the default labels for the rest
+
+    if args.verbose:
+        print('\nChecked the tabular EOS file labels, proceeding with the data loading...')
+
+# load the tabular EOS files
+tabular_eos_data = {}
+for i, tabular_eos_file in enumerate(args.tabular_eos_file):
+    eos_data_i = tabplot.EOS_data_loader(tabular_eos_file, tabular_eos_labels[i], args.verbose)
+    eos_data_i_label = eos_data_i['data_label'] # if the label was not provided, the EOS_data_loader function will assign a default label
+    tabular_eos_data[eos_data_i_label] = eos_data_i
+    tabular_eos_labels[i] = eos_data_i_label # update the label in case the default label was assigned
+
+if args.verbose:
+    print('\nLoaded the tabular EOS data.')
+    for i in range(len(tabular_eos_labels)):
+        print(f'Tabular EOS file: {args.tabular_eos_file[i]} with label: {tabular_eos_labels[i]}')
+
+if args.posterior_file is not None:
+    priors_labels = []
+    posterior_samples_labels = [None] * len(args.posterior_file)
+
+    if args.posterior_label is not None:
+        if len(args.posterior_label) < len(args.posterior_file):
+            warnings.warn('Number of posterior samples labels is less than the number of posterior samples files. The code will use the default labels after the last provided label.')
+        elif len(args.posterior_label) > len(args.posterior_file):
+            raise ValueError('Number of posterior samples labels is greater than the number of posterior samples files. Please check if you have provided the correct number of labels or files.')
+
+        posterior_samples_labels[:len(args.posterior_label)] = args.posterior_label 
+    
+        if args.verbose:
+            print('\nChecked the posterior samples labels, proceeding with the data loading...')
+
+    # load the posterior samples files
+    posterior_samples_data = {}
+    for i, posterior_file in enumerate(args.posterior_file):
+        posterior_data_i = tabplot.posterior_data_loader(posterior_file, posterior_samples_labels[i], args.verbose)
+        posterior_data_i_label = posterior_data_i['data_label']
+        posterior_samples_data[posterior_data_i_label] = posterior_data_i
+        posterior_samples_labels[i] = posterior_data_i_label
+
+    if args.verbose:
+        print('\nLoaded the posterior samples data.')
+        for i in range(len(posterior_samples_labels)):
+            print(f'Posterior samples file: {args.posterior_file[i]} with label: {posterior_samples_labels[i]}')
+
+    # make the posterior-tabular map if not provided by the user
+    if args.posterior_tabular_map is None:
+        # if the user did not provide the posterior-tabular map, the code will only use first tabular EOS file for the posterior samples
+        posterior_tabular_map = {tabular_eos_labels[0]: posterior_samples_labels}
+
+    # check if the map is provided in the correct format and all the labels are valid
+    else:
+        if args.verbose:
+            print('\nChecking the posterior-tabular map...')
+        posterior_tabular_map = ast.literal_eval(args.posterior_tabular_map)
+        if not isinstance(posterior_tabular_map, dict):
+            raise ValueError('The posterior-tabular map should be a dictionary. Please check the format of the input.')
+        for tabular_label in posterior_tabular_map.keys():
+            if tabular_label not in tabular_eos_labels:
+                raise ValueError(f'Tabular EOS label: {tabular_label} from your posterior-tabular map is not found in the tabular EOS labels. Please check the labels you provided.')
+            if isinstance(posterior_tabular_map[tabular_label], list):
+                for posterior_label in posterior_tabular_map[tabular_label]:
+                    if posterior_label not in posterior_samples_labels:
+                        raise ValueError(f'Posterior samples label: {posterior_label} from your posterior-tabular map is not found in the posterior samples labels. Please check the labels you provided.')
+            else:
+                if posterior_tabular_map[tabular_label] not in posterior_samples_labels:
+                    raise ValueError(f'Posterior samples label: {posterior_tabular_map[tabular_label]} from your posterior-tabular map is not found in the posterior samples labels. Please check the labels you provided.')
+
+    if args.verbose:
+        print('\nCreated the posterior-tabular map.')
+        for tabular_label in posterior_tabular_map.keys():
+            print(f'Tabular EOS label: {tabular_label} with posterior samples labels: {posterior_tabular_map[tabular_label]}')
+        print('\nMoving on to priors...')
+else:
+    posterior_samples_data = None
+    posterior_tabular_map = None
+    priors_labels = tabular_eos_labels # plot priors for all tabular EOS files if no posterior samples are provided
+    warnings.warn('No posterior samples files provided. The code will only plot the tabular EOS priors.')
+    
+# if the user specified the tabular EOS files to plot priors for, the code will plot priors for those files
+if args.plot_tabular_eos_prior is not None:
+    for tabular_label in args.plot_tabular_eos_prior:
+        if tabular_label not in tabular_eos_labels:
+            raise ValueError(f'Tabular EOS label for prior plot: {tabular_label} is not found in the tabular EOS labels. Please check the labels you provided.')
+    priors_labels = args.plot_tabular_eos_prior
+elif len(tabular_eos_labels) > 1 and posterior_samples_data is not None:
+    priors_labels = tabular_eos_labels[1:] # plot priors for all tabular EOS files except the first one
+
+if args.verbose:
+    print('\nChecked the tabular EOS labels for the priors.')
+    for i in range(len(priors_labels)):
+        print(f'Priors will be plotted for the tabular EOS file with label: {priors_labels[i]}')
+    print('\nLinking the tabular EOS data with the posterior samples data according to the posterior-tabular map...')
+
+plt.rcParams['figure.figsize'] = [15, 10]
+plt.rcParams['font.size'] = 12
+
+def EOS_plotter(args, tabular_eos_data: dict, posterior_samples_data: dict, posterior_tabular_map: dict, priors_labels: list, plot_type: str) -> None:
+    """
+    Function to plot the EOS inference results for the tabular EOS priors and posterior samples.
+    
+    Parameters:
+    ----------
+    args : argparse.Namespace
+        The argparse namespace object with the script arguments.
+    tabular_eos_data : dict
+        The dictionary with the tabular EOS data generated earlier in the script. 
+        Format: {tabular_label: tabular_eos_data}, tabular_eos_data should be generated by the EOS_data_loader function.
+    posterior_samples_data : dict
+        The dictionary with the posterior samples data generated earlier in the script. 
+        Format: {posterior_label: posterior_samples_data}, posterior_samples_data should be generated by the posterior_data_loader function.
+    posterior_tabular_map : dict
+        The dictionary with the posterior-tabular map generated earlier in the script. 
+        Format: {tabular_label: posterior_samples_label}, posterior_samples_label can be a list of labels or a single string label.
+    priors_labels : list
+        The list with the tabular EOS labels to plot priors for.
+    plot_type : str
+        The type of the plot to make. Can be 'pressure_density' or 'mass_radius'.
+
+    Returns:
+    -------
+    None
+
+    Raises:
+    -------
+    NOTE!
+    Errors will not be raised if the script has not been changed from the initial version. 
+    They are here to ensure future modifications do not break the code.
+
+    ValueError
+        If the plot type is not 'pressure_density' or 'mass_radius'. 
+    ValueError
+        If the posterior samples data is provided without the posterior-tabular map or vice versa.
+    """
+    if plot_type not in ['pressure_density', 'mass_radius']:
+        raise ValueError('The plot type should be either pressure_density or mass_radius. Please check the input.')
+    if (posterior_samples_data is None) != (posterior_tabular_map is None):
+        raise ValueError('The posterior samples data and the posterior-tabular map should be provided together. Please check the input.')
+
+    raw_plot_data = []
+
+    for tabular_label in priors_labels:
+        raw_plot_data.append(tabplot.link_eos_data_to_posterior(tabular_eos_data[tabular_label], plot_type))
+    
+    if args.verbose:
+        print(f'\nCollected the data for priors for the {plot_type} plot. Moving on to posteriors...')
+    
+    # link the tabular EOS data with the posterior samples data according to the posterior-tabular map
+    if posterior_samples_data is not None:
+        for tabular_label in posterior_tabular_map.keys():
+            if isinstance(posterior_tabular_map[tabular_label], list):
+                for posterior_label in posterior_tabular_map[tabular_label]:
+                    raw_plot_data.append(tabplot.link_eos_data_to_posterior(tabular_eos_data[tabular_label], plot_type, posterior_samples_data[posterior_label]))
+            else:
+                raw_plot_data.append(tabplot.link_eos_data_to_posterior(tabular_eos_data[tabular_label], plot_type, posterior_samples_data[posterior_tabular_map[tabular_label]]))
+
+        if args.verbose:
+            print(f'\nCollected the data for posterior samples for the {plot_type} plot. Processing...')
+    
+    # choose the colors for the plots
+    colors = [None] * len(raw_plot_data)
+    if args.color is not None:
+        if len(args.color) < len(raw_plot_data):
+            warnings.warn('Number of colors is less than the number of posterior samples files. The code will use the default colors for the rest of the files.')
+            colors[:len(args.color)] = args.color
+        else: 
+            colors = args.color 
+    if args.use_bgcgb_colormap:
+        colors[:5] = ['black', 'grey', 'cyan', 'green', 'blue']
+        if args.color is not None:
+            warnings.warn('You have chosen to use the BlackGreyCyanGreenBlue colormap. The code will ignore the first 5 colors you provided.')
+    if args.verbose and any(colors is not None for c in colors):
+        print(f'\nThe colors for the plots are: {colors}. Any of the None values will be replaced with the default colors. (tab10 colormap)')
+    
+    plot_data = []
+    if plot_type == 'pressure_density':
+        for i, raw_data in enumerate(raw_plot_data):
+            plot_data.append(tabplot.pressure_density_plot_data_gen(**raw_data, custom_color = colors[i]))
+        
+        if args.verbose:
+            print(f'\nProcessed the data for the {plot_type} plot. Plotting...')
+
+        tabplot.pressure_density_plot(*plot_data, title = args.plot_p_vs_rho_title)
+    
+    elif plot_type == 'mass_radius':
+        for i, raw_data in enumerate(raw_plot_data):
+            plot_data.append(tabplot.mass_radius_plot_data_gen(**raw_data, custom_color = colors[i]))
+
+        if args.verbose:
+            print(f'\nProcessed the data for the {plot_type} plot. Plotting...')
+
+        tabplot.mass_radius_plot(*plot_data, title = args.plot_m_vs_r_title)
+
+    return None
+    
+# plot the P vs rho EOS inference
+if args.plot_p_vs_rho:
+    EOS_plotter(args, tabular_eos_data, posterior_samples_data, posterior_tabular_map, priors_labels, 'pressure_density')
+
+# plot the M vs R EOS inference
+if args.plot_m_vs_r:
+    EOS_plotter(args, tabular_eos_data, posterior_samples_data, posterior_tabular_map, priors_labels, 'mass_radius')

--- a/MonteCarloMarginalizeCode/Code/bin/util_ConstructIntrinsicPosterior_GenericCoordinates.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_ConstructIntrinsicPosterior_GenericCoordinates.py
@@ -2277,7 +2277,7 @@ if opts.supplementary_prior_code:
   external_prior_module = sys.modules[opts.supplementary_prior_code]
   if hasattr(external_prior_module,'prior_pdf') and hasattr(external_prior_module,'param_ranges'):
       if type(external_prior_module.prior_pdf) == dict:
-          for name in externa_prior_module.prior_pdf:
+          for name in external_prior_module.prior_pdf:
               sampler.prior_pdf[name] = external_prior_module[name]
               sampler.llim[name],sampler.rlim
 


### PR DESCRIPTION
New files:
* `TabularEOSPlotUtilities.py` - function library for loading data from Landry format files, and posterior samples files (RIFT output format), modifying that data for plotting and data analysis purposes, and making EOS inference plots of $P$ vs $\rho$ and $M$ vs $R$
* `plot_tabular_eos_inference.py` - script that allows the user to make the EOS inference plots and requires input tabular EOS files and posterior samples files. This script allows the user to plot different priors and posteriors, customize labels, and colors, and choose the plots of interest

Modified files
* `util_ConstructIntrinsicPosterior_GenericCoordinates.py` - fixed a typo at line 2280