### PR TITLE
Fixed calmarg files to work with eccentric parameters

### DIFF
--- a/MonteCarloMarginalizeCode/Code/RIFT/calmarg/rift_source.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/calmarg/rift_source.py
@@ -132,7 +132,7 @@ def RIFT_lal_binary_black_hole_orig(
 
 def RIFT_lal_binary_black_hole(
         frequency_array, mass_1, mass_2, luminosity_distance, spin_1x, spin_1y, spin_1z,
-        spin_2x, spin_2y, spin_2z,iota, phase, **kwargs):
+        spin_2x, spin_2y, spin_2z,iota, phase, eccentricity, meanPerAno **kwargs):
 
     waveform_kwargs = dict(
         waveform_approximant='SEOBNRv4PHM', reference_frequency=15.0,
@@ -169,6 +169,8 @@ def RIFT_lal_binary_black_hole(
     P.deltaF=frequency_array[1]-frequency_array[0]
     P.incl = float(iota)
     P.phiref = float(phase)
+    P.eccentricity = float(eccentricity)
+    P.meanPerAno = float(meanPerAno)
     P.dist=luminosity_distance*lal.PC_SI*1e6
     P.approx = approximant
     P.taper = lalsim.SIM_INSPIRAL_TAPER_START

--- a/MonteCarloMarginalizeCode/Code/bin/calibration_reweighting.py
+++ b/MonteCarloMarginalizeCode/Code/bin/calibration_reweighting.py
@@ -248,8 +248,9 @@ elif (args.posterior_sample_file.split(".")[-1] == 'txt') or (args.posterior_sam
         result.posterior  = result.posterior.drop(columns=['lnL','ps'])
         result.posterior['p'] = np.log(result.posterior['p'])  # not sure if used, but if so define correctly
         key_swap_dict = {'m1':'mass_1', 'm2':'mass_2', 'a1x':'spin_1x', 'a1y':'spin_1y', 'a1z':'spin_1z',
-            'a2x':'spin_2x', 'a2y':'spin_2y', 'a2z':'spin_2z', 'incl':'iota', 'time':'geocent_time',
-        'phiorb':'phase', 'p':'log_prior', 'distance':'luminosity_distance', 'lambda1':'lambda_1', 'lambda2':'lambda_2'}
+                         'a2x':'spin_2x', 'a2y':'spin_2y', 'a2z':'spin_2z', 'incl':'iota', 'time':'geocent_time',
+                         'phiorb':'phase', 'p':'log_prior', 'distance':'luminosity_distance', 'lambda1':'lambda_1', 'lambda2':'lambda_2',
+                         'eccentricity':'eccentricity', 'meanPerAno':'mean_per_ano'}
 
         names = list(result.posterior.keys())  # dangerous to have iterator tied to changing structure
         for old_key in names:


### PR DESCRIPTION
Added eccentricity and meanPerAno to both rift_source.py and calibration_reweighting.py scripts