### PR TITLE
a6c changes

### DIFF
--- a/MonteCarloMarginalizeCode/Code/RIFT/misc/xmlutils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/misc/xmlutils.py
@@ -42,6 +42,7 @@ CMAP = { "right_ascension": "longitude",
     "joint_s_prior": "alpha3",
     "eccentricity":"alpha4",
     "meanPerAno":"alpha",
+    "a6c":"psi0",
     "lambda1":"alpha5",
     "lambda2":"alpha6",
     "spin1x":"spin1x",
@@ -54,7 +55,7 @@ CMAP = { "right_ascension": "longitude",
 
 # FIXME: Find way to intersect given cols with valid cols when making table.
 # Otherwise, we'll have to add them manually and ensure they all exist
-sim_valid_cols = ["simulation_id", "inclination", "longitude", "latitude", "polarization", "geocent_end_time", "geocent_end_time_ns", "coa_phase", "distance", "mass1", "mass2", "alpha", "alpha1", "alpha2", "alpha3", "alpha4", "alpha5", "alpha6", "spin1x", "spin1y", "spin1z", "spin2x", "spin2y", "spin2z"]
+sim_valid_cols = ["simulation_id", "inclination", "longitude", "latitude", "polarization", "geocent_end_time", "geocent_end_time_ns", "coa_phase", "distance", "mass1", "mass2", "alpha", "alpha1", "alpha2", "alpha3", "alpha4", "alpha5", "alpha6", "spin1x", "spin1y", "spin1z", "spin2x", "spin2y", "spin2z","psi0"]
 sngl_valid_cols = [ "event_id", "snr", "tau0", "tau3"]
 multi_valid_cols = ["process_id", "event_id", "snr"]
 

--- a/MonteCarloMarginalizeCode/Code/bin/convert_output_format_ile2inference
+++ b/MonteCarloMarginalizeCode/Code/bin/convert_output_format_ile2inference
@@ -38,6 +38,7 @@ optp.add_option("--export-tides",action='store_true',help="Include tidal paramet
 optp.add_option("--export-eos",action='store_true',help="Include EOS index parameter")
 optp.add_option("--export-cosmology",action='store_true',help="Include source frame masses and redshift")
 optp.add_option("--export-weights",action='store_true',help="Include a field 'weights' equal to L p/ps")
+optp.add_option("--export-EOB-parameters", action="store_true", help="Include EOB Parameter: a6c")
 optp.add_option("--export-eccentricity", action="store_true", help="Include eccentricity")
 optp.add_option("--export-meanPerAno", action="store_true", help="Include meanPerAno")
 optp.add_option("--with-cosmology",default="Planck15",help="Specific cosmology to use")
@@ -75,8 +76,12 @@ if opts.convention == 'LI':
   print("# m1 m2 a1x a1y a1z a2x a2y a2z mc eta  ra dec time phiorb incl psi  distance Npts lnL p ps neff  mtotal q chi_eff chi_p",end=' ')
   if opts.export_extra_spins:
       print( 'theta_jn phi_jl tilt1 tilt2 costilt1 costilt2 phi12 a1 a2 psiJ',end=' ')
-  if opts.export_tides:
+  if opts.export_tides and not (opts.export_EOB_parameters):
       print( "lambda1 lambda2 lam_tilde",end=' ')
+  if opts.export_tides and opts.export_EOB_parameters:
+      print( "lambda1 lambda2 lam_tilde a6c",end=' ')
+  if not (opts.export_tides) and opts.export_EOB_parameters:
+      print( "a6c")    
   if opts.export_eos:
       print( "eos_indx",end=' ')
   if opts.export_cosmology:
@@ -168,7 +173,14 @@ if opts.convention == 'LI':
             if hasattr(pt, 'alpha6'):
                 P.lambda2 = pt.alpha6
             lam_tilde = P.extract_param("LambdaTilde")
-            print( P.lambda1, P.lambda2, lam_tilde,end=' ')
+            if not (opts.export_EOB_parameters):
+                print( P.lambda1, P.lambda2, lam_tilde,end=' ')
+            if opts.export_EOB_parameters:
+                P.a6c=pt.psi0
+                print( P.lambda1, P.lambda2, lam_tilde, P.a6c,end=' ')
+        if not(opts.export_tides) and opts.export_EOB_parameters:
+            P.a6c=pt.psi0
+            print(P.a6c, end=' ')    
         if opts.export_eos:
             eos_indx = P.eos_table_index
             print(eos_indx, end=' ')
@@ -197,8 +209,12 @@ if opts.convention == 'LI':
 print( "# m1 m2 a1x a1y a1z a2x a2y a2z mc eta indx  Npts ra dec tref phiorb incl psi  dist p ps lnL mtotal q ",end=' ')
 if opts.export_extra_spins:
     print( 'thetaJN phi_jl tilt1 tilt2 phi12 a1 a2 psiJ',end=' ')
-if opts.export_tides:
+if opts.export_tides and not (opts.export_EOB_parameters):
     print( "lambda1 lambda2",end=' ')
+if opts.export_tides and opts.export_EOB_parameters:
+    print( "lambda1 lambda2 a6c",end=' ')
+if not (opts.export_tides) and opts.export_EOB_parameters:
+    print( "a6c")    
 if opts.export_eos:
       print( "eos_indx",end=' ')
 if opts.export_cosmology:
@@ -283,8 +299,12 @@ for fname in args:
                 True
             thetaJN, phiJL, theta1, theta2, phi12, chi1, chi2, psiJ = P.extract_system_frame()
             print( thetaJN, phiJL, theta1, theta2, phi12, chi1, chi2, psiJ,end=' ')
-        if opts.export_tides:
+        if opts.export_tides and not (opts.export_EOB_parameters):
             print(pt.alpha5, pt.alpha6,end=' ')
+        if opts.export_tides and opts.export_EOB_parameters:
+            print( pt.alpha5, pt.alpha6, pt.psi0,end=' ')
+        if not(opts.export_tides) and opts.export_EOB_parameters:
+                print(pt.psi0, end=' ')    
         if opts.export_eos:
             print(pt.alpha, end=' ')
         if opts.export_cosmology:

--- a/MonteCarloMarginalizeCode/Code/bin/create_event_parameter_pipeline_BasicIteration
+++ b/MonteCarloMarginalizeCode/Code/bin/create_event_parameter_pipeline_BasicIteration
@@ -237,6 +237,7 @@ parser.add_argument("--ile-runtime-max-minutes",default=None,type=int,help="If n
 parser.add_argument("--cip-exe",default=None,help="filename of CIP or equivalent executable. Will default to `which util_ConstructIntrinsicPosterior_GenericCoordinates` in low-level code")
 parser.add_argument("--cip-post-exe",default=None,help="filename of script to execute with SCRIPT POST joblist scripname JOBID RETURN worklevel in the dag. This will be run after each CIP completes in the main dag. Objective is to enable larger-scale CIP queues which work efficiently to a target work level (e.g,, n_eff). Note this script is responsible for reading htcondor logs to identify the run directory!")
 parser.add_argument("--cip-exe-G",default=None,help="filename of CIP or equivalent executable, as ALTERNATE CIP used when a 'G' iteration is requested ")
+parser.add_argument("--use-EOB-parameters",default=False,action='store_true')
 parser.add_argument("--use-eccentricity",default=False,action='store_true')
 parser.add_argument("--use-meanPerAno",default=False,action='store_true')
 parser.add_argument("--use-eccentricity-squared-sampling",default=False,action='store_true')
@@ -835,6 +836,8 @@ if  (opts.last_iteration_extrinsic):
 ##   Consolidate job(s)
 #   - consolidate output of single previous job
 con_arg_str = ''
+if opts.use_EOB_parameters:
+    con_arg_str += " --a6c "
 if opts.use_eccentricity:
     con_arg_str += " --eccentricity "
     if opts.use_meanPerAno:
@@ -859,6 +862,8 @@ con_job.write_sub_file()
 ##   Unify job
 #   - update 'all.net' to include all previous events
 unify_arg_str = ''
+if opts.use_EOB_parameters:
+    unify_arg_str += " --a6c "
 if opts.use_eccentricity:
     unify_arg_str += " --eccentricity "
     if opts.use_meanPerAno:
@@ -1491,6 +1496,8 @@ for it in np.arange(it_start,opts.n_iterations):
         cmd += " --neff-threshold {} ".format(opts.neff_threshold)
         cmd += " --general-request-disk {} --ile-request-disk {} --cip-request-disk {} ".format(opts.general_request_disk,opts.ile_request_disk,opts.cip_request_disk)
         cmd += " --request-memory-ILE {} --request-memory-CIP {} ".format(opts.request_memory_ILE,opts.request_memory_CIP)
+        if opts.use_EOB_parameters:
+            cmd += " --use-EOB-parameters "
         if opts.use_eccentricity:
             cmd += " --use-eccentricity "
             if opts.use_meanPerAno:

--- a/MonteCarloMarginalizeCode/Code/bin/integrate_likelihood_extrinsic_batchmode
+++ b/MonteCarloMarginalizeCode/Code/bin/integrate_likelihood_extrinsic_batchmode
@@ -250,6 +250,7 @@ optp.add_option("--internal-waveform-extra-lalsuite-args",type=str,default=None)
 optp.add_option("--internal-waveform-extra-kwargs",type=str,default=None)
 optp.add_option("--internal-precompute-ignore-threshold",default=None,type=float)
 optp.add_option("--verbose",action='store_true')
+optp.add_option("--save-EOB-parameters", action="store_true")
 optp.add_option("--save-eccentricity", action="store_true")
 optp.add_option("--save-meanPerAno", action="store_true")
 #
@@ -1874,16 +1875,23 @@ def analyze_event(P_list, indx_event, data_dict, psd_dict, fmax, opts,inv_spec_t
           else:  
             # output format when only eccentricity is being used
             numpy.savetxt(fname_output_txt, numpy.array([[event_id, m1, m2, P.s1x, P.s1y, P.s1z, P.s2x, P.s2y, P.s2z,  P.eccentricity, log_res+manual_avoid_overflow_logarithm, sqrt_var_over_res,sampler.ntotal, neff ]]))  #dict_return["convergence_test_results"]["normal_integral]"
+        elif not (P.lambda1>0 or P.lambda2>0) and opts.save_EOB_parameters:
+          numpy.savetxt(fname_output_txt, numpy.array([[event_id, m1, m2, P.s1x, P.s1y, P.s1z, P.s2x, P.s2y, P.s2z, P.a6c, log_res+manual_avoid_overflow_logarithm, sqrt_var_over_res,sampler.ntotal, neff ]]))  #dict_return["convergence_test_results"]["normal_integral]"
+        elif (P.lambda1>0 or P.lambda2>0) and opts.save_EOB_parameters:
+          numpy.savetxt(fname_output_txt, numpy.array([[event_id, m1, m2, P.s1x, P.s1y, P.s1z, P.s2x, P.s2y, P.s2z,  P.lambda1, P.lambda2, P.a6c, log_res+manual_avoid_overflow_logarithm, sqrt_var_over_res,sampler.ntotal, neff ]]))  #dict_return["convergence_test_results"]["normal_integral]"
         elif not (P.lambda1>0 or P.lambda2>0):
           # output format when lambda is NOT used
           if not opts.pin_distance_to_sim:
             numpy.savetxt(fname_output_txt, numpy.array([[event_id, m1, m2, P.s1x, P.s1y, P.s1z, P.s2x, P.s2y, P.s2z,  log_res+manual_avoid_overflow_logarithm, sqrt_var_over_res,sampler.ntotal, neff ]]))  #dict_return["convergence_test_results"]["normal_integral]"
+#          elif opts.save_EOB_parameters:
+
           else:
             numpy.savetxt(fname_output_txt, numpy.array([[event_id, m1, m2, P.s1x, P.s1y, P.s1z, P.s2x, P.s2y, P.s2z, pinned_params["distance"], log_res+manual_avoid_overflow_logarithm, sqrt_var_over_res,sampler.ntotal, neff ]]))  #dict_return["convergence_test_results"]["normal_integral]"
         else:
           if not(opts.export_eos_index):
             # Alternative output format if lambda is active
             numpy.savetxt(fname_output_txt, numpy.array([[event_id, m1, m2, P.s1x, P.s1y, P.s1z, P.s2x, P.s2y, P.s2z,  P.lambda1, P.lambda2, log_res+manual_avoid_overflow_logarithm, sqrt_var_over_res,sampler.ntotal, neff ]]))  #dict_return["convergence_test_results"]["normal_integral]"
+#          elif opts.save_EOB_parameters:
           else:
             numpy.savetxt(fname_output_txt, numpy.array([[event_id, m1, m2, P.s1x, P.s1y, P.s1z, P.s2x, P.s2y, P.s2z,  P.lambda1, P.lambda2, P.eos_table_index, log_res+manual_avoid_overflow_logarithm, sqrt_var_over_res,sampler.ntotal, neff ]]))  #dict_return["convergence_test_results"]["normal_integral]"
 
@@ -1959,6 +1967,7 @@ def analyze_event(P_list, indx_event, data_dict, psd_dict, fmax, opts,inv_spec_t
             samples["spin2z"] =numpy.ones(samples["psi"].shape)*P.s2z
             samples["alpha4"] =numpy.ones(samples["psi"].shape)*P.eccentricity
             samples["alpha"] =numpy.ones(samples["psi"].shape)*P.meanPerAno
+            samples["a6c"] =numpy.ones(samples["psi"].shape)*P.a6c
             samples["alpha5"] =numpy.ones(samples["psi"].shape)*P.lambda1
             samples["alpha6"] =numpy.ones(samples["psi"].shape)*P.lambda2
             # Below exist solely to placate XML export; new issue as of latest lalsuite say 7.15+ or so
@@ -1971,7 +1980,7 @@ def analyze_event(P_list, indx_event, data_dict, psd_dict, fmax, opts,inv_spec_t
 #        print(samples['t_ref'] - fiducial_epoch, len(samples['t_ref']))
       xmlutils.append_samples_to_xmldoc(xmldoc, samples)
         # Extra metadata
-      dict_out={"mass1": m1, "mass2": m2, "spin1z": P.s1z, "spin2z": P.s2z, "alpha4": P.eccentricity, "alpha": P.meanPerAno, "alpha5":P.lambda1, "alpha6":P.lambda2, "event_duration": sqrt_var_over_res, "ttotal": sampler.ntotal}
+      dict_out={"mass1": m1, "mass2": m2, "spin1z": P.s1z, "spin2z": P.s2z, "alpha4": P.eccentricity, "alpha": P.meanPerAno, "alpha5":P.lambda1, "alpha6":P.lambda2, "event_duration": sqrt_var_over_res, "ttotal": sampler.ntotal, "psi0": P.a6c}
 #      if 'distance' in pinned_params:
 #            dict_out['distance'] = pinned_params["distance"]
       converged_result = False

--- a/MonteCarloMarginalizeCode/Code/bin/util_CleanILE.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_CleanILE.py
@@ -28,6 +28,7 @@ col_intrinsic = 9
 import argparse
 parser = argparse.ArgumentParser(usage="util_CleanILE.py fname1.dat fname2.dat ... ")
 parser.add_argument("fname",action='append',nargs='+')
+parser.add_argument("--a6c", action="store_true")
 parser.add_argument("--eccentricity", action="store_true")
 parser.add_argument("--meanPerAno", action="store_true")
 #Askold: adding specification for tabular eos file
@@ -69,6 +70,13 @@ for fname in opts.fname[0]: #sys.argv[1:]:
             tides_on  = True
             col_intrinsic =11
             indx, m1,m2, s1x,s1y,s1z,s2x,s2y,s2z, lambda1,lambda2,lnL, sigmaOverL, ntot, neff = line
+        elif opts.a6c and len(line)==16:
+            tides_on  = True
+            col_intrinsic =12
+            indx, m1,m2, s1x,s1y,s1z,s2x,s2y,s2z, lambda1,lambda2,a6c,lnL, sigmaOverL, ntot, neff = line
+        elif opts.a6c and len(line)==14:
+            col_intrinsic =10
+            indx, m1,m2, s1x,s1y,s1z,s2x,s2y,s2z,a6c,lnL, sigmaOverL, ntot, neff = line
 
         #Askold: adding the option for tabular eos file
         elif opts.tabular_eos_file and len(line) == 16: #checking if the tabular eos file is defined in the parser and if the line actually has all the columns
@@ -102,7 +110,7 @@ for key in data_at_intrinsic:
             print(-1, key[0],key[1], key[2], key[3],key[4], key[5],key[6], key[7], key[8], key[9], lnLmeanMinusLmax+lnLmax, sigmaNetOverL, np.sum(ntot), -1)
         else:
             print(-1, key[0],key[1], key[2], key[3],key[4], key[5],key[6], key[7], key[8], lnLmeanMinusLmax+lnLmax, sigmaNetOverL, np.sum(ntot), -1)
-    elif tides_on:
+    elif tides_on and not (opts.a6c):
         print(-1, key[0],key[1], key[2], key[3],key[4], key[5],key[6], key[7], key[8],key[9], lnLmeanMinusLmax+lnLmax, sigmaNetOverL, np.sum(ntot), -1)
     elif distance_on:
         print(-1, key[0],key[1], key[2], key[3],key[4], key[5],key[6], key[7], key[8], lnLmeanMinusLmax+lnLmax, sigmaNetOverL, np.sum(ntot), -1)
@@ -110,6 +118,10 @@ for key in data_at_intrinsic:
     #Askold: new option for tabular eos file
     elif opts.tabular_eos_file: #written similarly to the previous ones
         print(-1, key[0],key[1], key[2], key[3],key[4], key[5],key[6], key[7], key[8],key[9], key[10],  lnLmeanMinusLmax+lnLmax, sigmaNetOverL, np.sum(ntot), -1)
-    
+    elif opts.a6c:
+        if tides_on:
+            print(-1, key[0],key[1], key[2], key[3],key[4], key[5],key[6], key[7], key[8],key[9],key[10], lnLmeanMinusLmax+lnLmax, sigmaNetOverL, np.sum(ntot), -1)
+        else:
+            print(-1,  key[0],key[1], key[2], key[3],key[4], key[5],key[6], key[7], key[8], lnLmeanMinusLmax+lnLmax, sigmaNetOverL, np.sum(ntot), -1)            
     else:
         print(-1,  key[0],key[1], key[2], key[3],key[4], key[5],key[6], key[7], lnLmeanMinusLmax+lnLmax, sigmaNetOverL, np.sum(ntot), -1)

--- a/MonteCarloMarginalizeCode/Code/bin/util_ConstructIntrinsicPosterior_GenericCoordinates.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_ConstructIntrinsicPosterior_GenericCoordinates.py
@@ -285,6 +285,8 @@ parser.add_argument("--mirror-points",action='store_true',help="Use if you have 
 parser.add_argument("--cap-points",default=-1,type=int,help="Maximum number of points in the sample, if positive. Useful to cap the number of points ued for GP. See also lnLoffset. Note points are selected AT RANDOM")
 parser.add_argument("--chi-max", default=1,type=float,help="Maximum range of 'a' allowed.  Use when comparing to models that aren't calibrated to go to the Kerr limit.")
 parser.add_argument("--chi-small-max", default=None,type=float,help="Maximum range of 'a' allowed on the smaller body.  If not specified, defaults to chi_max")
+parser.add_argument("--a6c-max", default=-20,type=float,help="Maximum range of 'a6c' allowed.")
+parser.add_argument("--a6c-min", default=-80,type=float,help="Minimum range of 'a6c' allowed.")
 parser.add_argument("--ecc-max", default=0.9,type=float,help="Maximum range of 'eccentricity' allowed.")
 parser.add_argument("--ecc-min", default=0.0,type=float,help="Minimum range of 'eccentricity' allowed.")
 parser.add_argument("--meanPerAno-max", default=2*np.pi,type=float,help="Maximum range of 'meanPerAno' allowed.")
@@ -356,6 +358,7 @@ parser.add_argument("--internal-correlate-parameters",default=None,type=str,help
 parser.add_argument("--internal-n-comp",default=1,type=int,help="number of components to use for GMM sampling. Default is 1, because we expect a unimodal posterior in well-adapted coordinates.  If you have crappy coordinates, use more")
 parser.add_argument("--internal-gmm-memory-chisquared-factor",default=None,type=float,help="Multiple of the number of degrees of freedom to save. 5 is a part in 10^6, 4 is 10^{-4}, and None keeps all up to lnL_offset.  Note that low-weight points can contribute notably to n_eff, and it can be dangerous to assume a simple chisquared likelihood!  Provided in case we need very long runs")
 parser.add_argument("--assume-eos-but-primary-bh",action='store_true',help="Special case of known EOS, but primary is a BH")
+parser.add_argument("--use-EOB-parameters", action="store_true")
 parser.add_argument("--use-eccentricity", action="store_true")
 parser.add_argument("--use-meanPerAno", action="store_true")
 parser.add_argument("--tripwire-fraction",default=0.05,type=float,help="Fraction of nmax of iterations after which n_eff needs to be greater than 1+epsilon for a small number epsilon")
@@ -389,6 +392,8 @@ if opts.check_good_enough:
 
 if not(opts.no_adapt_parameter):
     opts.no_adapt_parameter =[] # needs to default to empty list
+A6C_MAX = opts.a6c_max
+A6C_MIN = opts.a6c_min
 ECC_MAX = opts.ecc_max
 ECC_MIN = opts.ecc_min
 MEANPERANO_MAX = 2*np.pi
@@ -856,6 +861,9 @@ def tapered_magnitude_prior_alt(x,loc=0.8,kappa=20.):   #
     
     return 1/(1+f1)
 
+def a6c_prior(x):
+    return np.ones(x.shape) / (A6C_MAX-A6C_MIN) # uniform over the interval [A6C, A6C_MAX]
+
 def eccentricity_prior(x):
     return np.ones(x.shape) / (ECC_MAX-ECC_MIN) # uniform over the interval [0.0, ECC_MAX]
 
@@ -913,6 +921,7 @@ prior_map  = { "mtot": M_prior, "q":q_prior, "s1z":s_component_uniform_prior, "s
     's1z_bar':normalized_zbar_prior,
     's2z_bar':normalized_zbar_prior,
     # Other priors
+    'a6c':a6c_prior,
     'eccentricity':eccentricity_prior,
     'eccentricity_squared':eccentricity_squared_prior,
     'meanPerAno':meanPerAno_prior,
@@ -933,6 +942,7 @@ prior_range_map = {"mtot": [1, 300], "q":[0.01,1], "s1z":[-0.999*chi_max,0.999*c
   'lambda2':[lambda_min,lambda_small_max],
   'lambda_plus':[lambda_min,lambda_plus_max],
   'lambda_minus':[-lambda_max,lambda_max],  # will include the true region always...lots of overcoverage for small lambda, but adaptation will save us.
+  'a6c':[A6C_MIN, A6C_MAX],
   'eccentricity':[ECC_MIN, ECC_MAX],
   'eccentricity_squared':[ECC_MIN**2, ECC_MAX**2],
   'meanPerAno':[MEANPERANO_MIN, MEANPERANO_MAX],
@@ -1435,54 +1445,6 @@ def fit_rf(x,y,y_errors=None,fname_export='nn_fit',verbose=False):
     print( "    std ", np.std(residuals), np.max(y), np.max(fn_return(x)))
     return fn_return
 
-def fit_rf_pca(x,y,y_errors=None,fname_export='nn_fit'):
-    # from aasim
-#    from sklearn.ensemble import RandomForestRegressor
-    from sklearn.ensemble import ExtraTreesRegressor
-    from sklearn.decomposition import PCA
-    from sklearn.preprocessing import StandardScaler
-    x_scaler = StandardScaler()
-    x_scaled = x_scaler.fit_transform(x)
-    pca = PCA()
-    x_pca = pca.fit_transform(x_scaled)
-    # Instantiate model. Usually not that many structures to find, don't overcomplicate
-    #   - should scale like number of samples
-    rf = ExtraTreesRegressor(n_estimators=100, verbose=True,n_jobs=-1) # no more than 5% of samples in a leaf
-
-    if y_errors is None:
-        rf.fit(x_pca,y)
-    else:
-        rf.fit(x_pca,y,sample_weight=1./y_errors**2)
-
-    ### reject points with infinities : problems for inputs
-    def fn_return(x_in,rf=rf):
-        f_out = -100000*np.ones(len(x_in))
-        # remove infinity or Nan
-        indx_ok = np.all(np.isfinite(x_in),axis=-1)
-        # rf internally uses float32, so we need to remove points > 10^37 or so ! 
-        #    ... this *should* never happen due to bounds constraints, but ...
-        indx_ok_size = np.all( np.logical_not(np.greater(np.abs(x_in),1e37)), axis=-1)
-        indx_ok = np.logical_and(indx_ok, indx_ok_size)
-
-        f_out[indx_ok] = rf.predict(pca.transform(x_scaler.transform(x_in[indx_ok])))
-        return f_out
-#    fn_return = lambda x_in: rf.predict(x_in) 
-
-    print( " Demonstrating RF")   # debugging
-    residuals = rf.predict(pca.transform(x_scaler.transform(x)))-y
-    print( "    std ", np.std(residuals), np.max(y), np.max(fn_return(x)))
-    return fn_return
-
-def fit_rbf(x,y,y_errors=None,fname_export='rbf_fit',verbose=False):
-    from scipy.interpolate import RBFInterpolator
-    #   - should scale like number of samples
-    rbf = RBFInterpolator(x,y)
-
-    print( " Demonstrating RBF")   # debugging
-    residuals = rbf(x)-y
-    print( "    std ", np.std(residuals), np.max(y), np.max(rbf(x)))
-    return rbf
-
 def fit_nn_rfwrapper(x,y,y_errors=None,fname_export='nn_fit'):
     from sklearn.ensemble import RandomForestRegressor
     # Instantiate model. Usually not that many structures to find, don't overcomplicate
@@ -1663,6 +1625,7 @@ n_params = -1
 ###
 #  id m1 m2  lnL sigma/L  neff
 col_lnL = 9
+col_a6c = None
 col_eccentricity = None
 col_meanPerAno = None
 col_lambda1 = None
@@ -1684,6 +1647,10 @@ if opts.input_tides:
             low_level_coord_names += ['ordering'] 
         print(" Revised fit coord names (for lookup) : ", coord_names) # 'eos_table_index' will be overwritten here
         print(" Revised sampling coord names  : ", low_level_coord_names)
+    if opts.use_EOB_parameters:
+        print(" EOB parameters (a6c) with tides input: [",A6C_MIN, ", ",A6C_MAX, "]")
+        col_lnL += 1
+        col_a6c = col_lnL -1
 elif opts.use_eccentricity:
     print(" Eccentricity input: [",ECC_MIN, ", ",ECC_MAX, "]")
     if opts.use_meanPerAno:
@@ -1698,6 +1665,11 @@ elif opts.use_eccentricity:
 if opts.input_distance:
     print(" Distance input")
     col_lnL +=1
+if opts.use_EOB_parameters and not (opts.input_tides):
+    print(" EOB parameters (a6c) input: [",A6C_MIN, ", ",A6C_MAX, "]")
+    col_lnL += 1
+    col_a6c = col_lnL -1
+    
 dat_orig = dat = np.loadtxt(opts.fname)
 dat_orig = dat[dat[:,col_lnL].argsort()] # sort  http://stackoverflow.com/questions/2828059/sorting-arrays-in-numpy-by-column
 if col_meanPerAno:
@@ -1788,6 +1760,8 @@ for line in dat:
         P.lambda2 = line[col_lambda1+1]
     if opts.input_eos_index:
         P.eos_table_index = line[col_lambda1+2]
+    if opts.use_EOB_parameters:
+        P.a6c = line[col_a6c]  # 9
     if opts.use_eccentricity:
         P.eccentricity = line[col_eccentricity]  # 9
         if opts.use_meanPerAno:
@@ -2154,38 +2128,6 @@ elif opts.fit_method == 'rf':
         Y_err=Y_err[indx]
         dat_out_low_level_coord_names = dat_out_low_level_coord_names[indx]
     my_fit = fit_rf(X,Y,y_errors=Y_err)
-elif opts.fit_method == 'rf_pca':
-    print( " FIT METHOD ", opts.fit_method, " IS RF-pca ")
-    # NO data truncation for NN needed?  To be *consistent*, have the code function the same way as the others
-    X=X[indx_ok]
-    Y=Y[indx_ok] - lnL_shift
-    Y_err = Y_err[indx_ok]
-    dat_out_low_level_coord_names =     dat_out_low_level_coord_names[indx_ok]
-    # Cap the total number of points retained, AFTER the threshold cut
-    if opts.cap_points< len(Y) and opts.cap_points> 100:
-        n_keep = opts.cap_points
-        indx = np.random.choice(np.arange(len(Y)),size=n_keep,replace=False)
-        Y=Y[indx]
-        X=X[indx]
-        Y_err=Y_err[indx]
-        dat_out_low_level_coord_names = dat_out_low_level_coord_names[indx]
-    my_fit = fit_rf_pca(X,Y,y_errors=Y_err)
-elif opts.fit_method == 'rbf':
-    print( " FIT METHOD ", opts.fit_method, " IS RBF; **errors not used! **")
-    # NO data truncation for NN needed?  To be *consistent*, have the code function the same way as the others
-    X=X[indx_ok]
-    Y=Y[indx_ok] - lnL_shift
-    Y_err = Y_err[indx_ok]
-    dat_out_low_level_coord_names =     dat_out_low_level_coord_names[indx_ok]
-    # Cap the total number of points retained, AFTER the threshold cut
-    if opts.cap_points< len(Y) and opts.cap_points> 100:
-        n_keep = opts.cap_points
-        indx = np.random.choice(np.arange(len(Y)),size=n_keep,replace=False)
-        Y=Y[indx]
-        X=X[indx]
-        Y_err=Y_err[indx]
-        dat_out_low_level_coord_names = dat_out_low_level_coord_names[indx]
-    my_fit = fit_rbf(X,Y,y_errors=Y_err)
 elif opts.fit_method == 'nn_rfwrapper':
     print( " FIT METHOD ", opts.fit_method, " IS NN with RF wrapper ")
     # NO data truncation for NN needed?  To be *consistent*, have the code function the same way as the others
@@ -2374,9 +2316,8 @@ elif opts.sampler_method == "portfolio":
         print('PORTFOLIO: adding {} '.format(name))
         sampler_list.append(sampler)
     sampler = mcsamplerPortfolio.MCSampler(portfolio=sampler_list)
-elif mcsampler_Portfolio_ok:
-    if opts.sampler_method in mcsamplerPortfolio.known_pipelines: # access from plugins
-        sampler = mcsamplerPortfolio.known_pipelines[opts.sampler_method]()
+elif opts.sampler_method in mcsamplerPortfolio.known_pipelines: # access from plugins
+  sampler = mcsamplerPortfolio.known_pipelines[opts.sampler_method]()
 
 
 ##

--- a/MonteCarloMarginalizeCode/Code/bin/util_ILEdagPostprocess.sh
+++ b/MonteCarloMarginalizeCode/Code/bin/util_ILEdagPostprocess.sh
@@ -28,6 +28,8 @@ if [ "$3" == '--eccentricity' ]; then
     else
 	util_CleanILE.py ${RND}_tmp.dat $3 | sort -rg -k11 > $BASE_OUT.composite
     fi
+elif [ "$3" == '--a6c' ]; then
+    util_CleanILE.py ${RND}_tmp.dat $3 | sort -rg -k13 > $BASE_OUT.composite
 else
     util_CleanILE.py ${RND}_tmp.dat $3 | sort -rg -k10 > $BASE_OUT.composite
 fi

--- a/MonteCarloMarginalizeCode/Code/bin/util_LALWriteFrame.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_LALWriteFrame.py
@@ -38,7 +38,9 @@ parser.add_argument("--fref", dest='fref', type=float, default=0.0, help="Wavefo
 parser.add_argument("--incl",default=None,help="Set the inclination of L (at fref). Particularly helpful for aligned spin tests")
 parser.add_argument("--mass1",default=10,type=float,help='Mass 1 (solar masses)')
 parser.add_argument("--mass2",default=1.4,type=float,help='Mass 2 (solar masses)')
+parser.add_argument("--l-max",default=4,type=float,help='Inclusion of modes in injection')
 parser.add_argument("--verbose", action="store_true",default=False)
+parser.add_argument("--use-hlms-as-injections", action="store_true",default=False)
 opts=  parser.parse_args()
 
 
@@ -86,7 +88,14 @@ if T_est < opts.seglen:
 
 
 # Generate signal
-hoft = lalsimutils.hoft(P)   # include translation of source, but NOT interpolation onto regular time grid
+#hoft = lalsimutils.hoft(P)   # include translation of source, but NOT interpolation onto regular time grid
+if not (opts.use_hlms_as_injections):
+    print("Injecting with hoft")
+    hoft = lalsimutils.hoft(P,approx_string=opts.approx)
+else:
+    print("Injecting with hlms")
+    hlm = lalsimutils.hlmoft(P,Lmax=opts.l_max)
+    hoft = lalsimutils.hoft_from_hlm(hlm,P)
 epoch_orig = hoft.epoch
 # zero pad to be opts.seglen long, if necessary
 if opts.seglen/hoft.deltaT > hoft.data.length:


### PR DESCRIPTION
Added changes needed to be able to use a6c (an EOB parameter) as a recovered parameter; also added some of the changes needed for hyperbolic analyses. a6c should be able to be run with either with (currently recommended) or without tides). Only works for TEOBResumS and only without gwsignal.