### PR TITLE
Minor updates to CIP and CEP

### DIFF
--- a/MonteCarloMarginalizeCode/Code/bin/util_ConstructEOSPosterior.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_ConstructEOSPosterior.py
@@ -821,7 +821,16 @@ if len(coord_names) < len(dat_orig_names): # not needed if all params are in fit
 
     if len(dat) < opts.n_output_samples:
         print(" NOTE: original data shorter than  requested output; adding",opts.n_output_samples-len(dat),"duplicate fill lines from original data.")
-        newlines = dat[:opts.n_output_samples-len(dat)] #duplicate lines to fill
+        newlines = None
+        if opts.n_output_samples > 2*len(dat):
+            newlines = dat[:]
+            newlen = len(newlines)
+            while newlen < opts.n_output_samples:
+                newerlines = dat[:opts.n_output_samples-newlen] #will only get up to len(dat) lines
+                newlines = np.concatenate((newlines,newerlines), axis=0)
+                newlen = len(newlines)
+        else:
+            newlines = dat[:opts.n_output_samples-len(dat)] #duplicate lines to fill
         dat = np.concatenate((dat,newlines), axis=0) #should be fine since dat isn't used after this
         
     for c in np.arange(len(dat_orig_names)):
@@ -839,5 +848,15 @@ for indx in np.arange(len(coord_names)):
     outindx = name_index_dict[ coord_names[indx]]   # write in correct place
     dat_out[:,outindx] = vals
 
+# NOTE: if m1 or m2 is "constant" (i.e., not in samples), the possibility for m2 > m1 arises! Re-sort masses here to avoid; use below code.
+#if ("m1" not in coord_names) or ("m2" not in coord_names):
+#    print(" NOTE: re-sorting masses so m1 > m2 (precaution)")
+#    m1dx = name_index_dict["m1"]
+#    m1 = np.maximum(dat_out[:,m1dx], dat_out[:,m1dx+1]) #N.B.: assumes m2 col index after m1 col
+#    m2 = np.minimum(dat_out[:,m1dx], dat_out[:,m1dx+1])
+#    dat_out[:,m1dx] = m1
+#    dat_out[:,m1dx+1] = m2
+
 print(" Saving to ", opts.fname_output_samples+".dat")
 np.savetxt(opts.fname_output_samples+".dat",dat_out,header=" lnL sigma_lnL " + ' '.join(dat_orig_names))
+

--- a/MonteCarloMarginalizeCode/Code/bin/util_ConstructIntrinsicPosterior_GenericCoordinates.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_ConstructIntrinsicPosterior_GenericCoordinates.py
@@ -416,6 +416,14 @@ if  opts.input_eos_index and not(opts.tabular_eos_file):
     print(" warning: input EOS index, but not using it; presumably you are doing a model-free test ")
 if  not(opts.input_eos_index) and (opts.tabular_eos_file):
     raise Exception(" Fail: must process EOS input to be able to use it ")
+# ensure using_eos_index valid for eos file length
+if opts.using_eos and opts.using_eos.startswith('file:') and not(opts.using_eos_index is None):
+    fname = opts.using_eos.replace('file:', '')
+    try:
+        dat = np.loadtxt(fname)[opts.using_eos_index]
+    except Exception as e:
+        print(" Fail: EOS index out of range:\n   ",e)
+        sys.exit(0)
 
 my_eos=None
 #option to be used if gridded values not calculated assuming EOS


### PR DESCRIPTION
1. Added check to CIP to make sure `--using-eos-index` does not exceed the length of the `--using-eos` file; exits with success if index is out of range. (This avoids crashes caused by downselecting params during `grid-puff.dat` creation.)
2. Fixed original data duplication for "constant" parameters (i.e., params not being sampled) in `util_ConstructEOSPosterior.py` to match length of requested samples (`opts.n_output_samples`) even when `opts.n_output_samples > 2*len(dat_orig)` (avoids crashes caused by ragged arrays). 