### PR TITLE
Adding calmarg+osg operation

### DIFF
--- a/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
@@ -2366,9 +2366,9 @@ def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None
     # Write transfer file list.  Will handle any surrogates + pickle/container files.
     if not transfer_files is None:
         if not isinstance(transfer_files, list):
-            fname_str=transfer_files + ' '.join(extra_files)
+            fname_str=transfer_files # + ' '.join(extra_files)
         else:
-            fname_str = ','.join(transfer_files+extra_files)
+            fname_str = ','.join(transfer_files)
         fname_str=fname_str.strip()
         ile_job.add_condor_cmd('transfer_input_files', fname_str)
         ile_job.add_condor_cmd('should_transfer_files','YES')

--- a/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
@@ -2255,6 +2255,16 @@ def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None
     if exe is None:
         print(" Calibration Reweighting code not available. ")
         sys.exit(0)
+    if use_singularity:
+        exe_base = os.path.basename(exe)
+#        print((" Executable: name breakdown ", path_split, " from ", exe))
+        singularity_base_exe_path = "/opt/lscsoft/rift/MonteCarloMarginalizeCode/Code/"  # should not hardcode this ...!
+        if 'SINGULARITY_BASE_EXE_DIR' in list(os.environ.keys()) :
+            singularity_base_exe_path = os.environ['SINGULARITY_BASE_EXE_DIR']
+        else:
+#            singularity_base_exe_path = "/opt/lscsoft/rift/MonteCarloMarginalizeCode/Code/"  # should not hardcode this ...!
+            singularity_base_exe_path = "/usr/bin/"  # should not hardcode this ...!
+        exe=singularity_base_exe_path + exe_base
 
     ile_job = pipeline.CondorDAGJob(universe="vanilla", executable=exe)
     # This is a hack since CondorDAGJob hides the queue property

--- a/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
@@ -2225,7 +2225,7 @@ def write_subdagILE_sub(tag='subdag_ile', full_path_name=True, exe=None, univers
     return ile_job, ile_sub_name
 
 
-def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None, log_dir=None, ncopies=1,request_memory=8192,time_marg=True,pickle_file=None,posterior_file=None,universe='vanilla',no_grid=False,ile_args=None,n_cal=100,**kwargs):
+def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None, log_dir=None, ncopies=1,request_memory=8192,time_marg=True,pickle_file=None,posterior_file=None,universe='vanilla',no_grid=False,ile_args=None,n_cal=100,use_osg=False,use_oauth_files=False,singularity_image=None,transfer_files=None,**kwargs):
     """
     Write a submit file for launching jobs to reweight final posterior samples due to calibration uncertainty 
 
@@ -2234,6 +2234,8 @@ def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None
     Outputs:
      - reweighted samples due to calibration uncertainty and corresponding weights
     """
+    transfer_files = None
+    
     exe = exe or which("calibration_reweighting.py")
     if exe is None:
         print(" Calibration Reweighting code not available. ")
@@ -2250,6 +2252,21 @@ def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None
 
 
     requirements =[]
+    # Containerization basics
+    if use_singularity:
+        # Compare to https://github.com/lscsoft/lalsuite/blob/master/lalinference/python/lalinference/lalinference_pipe_utils.py
+        ile_job.add_condor_cmd('request_CPUs', str(1))
+        ile_job.add_condor_cmd('transfer_executable', 'False')
+        ile_job.add_condor_cmd("MY.SingularityBindCVMFS", 'True')
+        ile_job.add_condor_cmd("MY.SingularityImage", '"' + singularity_image_used + '"')
+        requirements.append("HAS_SINGULARITY=?=TRUE")
+    if use_oauth_files:
+        # we are using some authentication to retrieve files from the file transfer list, for example, from distributed hosts, not just submit. eg urls provided
+            ile_job.add_condor_cmd('use_oauth_services',use_oauth_files)
+    if use_singularity or use_osg:
+            # Set up file transfer options
+           ile_job.add_condor_cmd("when_to_transfer_output",'ON_EXIT')
+
     #
     # Logging options
     #
@@ -2260,8 +2277,14 @@ def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None
 
     #
     # Add mandatory options
-    ile_job.add_opt('data_dump_file', str(pickle_file))
-    ile_job.add_opt('posterior_sample_file', str(posterior_file))
+    pickke_file_arg = str(pickle_file)
+    post_file_arg = str(posterior_fie)
+    if use_osg:
+        transfer_files = pickle_file_arg + ',' + post_file_arg
+        pickle_file_arg = os.path.basename(pickle_file_arg)
+        post_file_arg = os.path.basename(post_file_arg)
+    ile_job.add_opt('data_dump_file', str(pickle_file_arg))
+    ile_job.add_opt('posterior_sample_file', str(post_file_arg))
     ile_job.add_opt('number_of_calibration_curves', str(n_cal))
     ile_job.add_opt('reevaluate_likelihood', 'True')
     ile_job.add_opt('use_rift_samples', 'True')
@@ -2325,6 +2348,21 @@ def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None
     # Write requirements
     ile_job.add_condor_cmd('requirements', '&&'.join('({0})'.format(r) for r in requirements))
 
+    # Write transfer file list.  Will handle any surrogates + pickle/container files.
+    if not transfer_files is None:
+        if not isinstance(transfer_files, list):
+            fname_str=transfer_files + ' '.join(extra_files)
+        else:
+            fname_str = ','.join(transfer_files+extra_files)
+        fname_str=fname_str.strip()
+        ile_job.add_condor_cmd('transfer_input_files', fname_str)
+        ile_job.add_condor_cmd('should_transfer_files','YES')
+
+    # Stream log info
+    if not ('RIFT_NOSTREAM_LOG' in os.environ):
+        ile_job.add_condor_cmd("stream_error",'True')
+        ile_job.add_condor_cmd("stream_output",'True')
+    
     try:
         ile_job.add_condor_cmd('accounting_group',os.environ['LIGO_ACCOUNTING'])
         ile_job.add_condor_cmd('accounting_group_user',os.environ['LIGO_USER_NAME'])

--- a/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
@@ -2285,6 +2285,11 @@ def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None
         ile_job.add_condor_cmd("MY.SingularityBindCVMFS", 'True')
         ile_job.add_condor_cmd("MY.SingularityImage", '"' + singularity_image_used + '"')
         requirements.append("HAS_SINGULARITY=?=TRUE")
+        print(" WARNING: cal reweighting requires bilby. Directories are moved to cal_evelopes")
+#        os.system("condor_config_val UID_DOMAIN > uid_domain.txt")
+#       with open("uid_domain.txt", 'r') as f:
+#            uid_domain = f.readline().strip()
+#            requirements.append(' UidDomain =?= "{}"'.format(uid_domain))
     if use_oauth_files:
         # we are using some authentication to retrieve files from the file transfer list, for example, from distributed hosts, not just submit. eg urls provided
             ile_job.add_condor_cmd('use_oauth_services',use_oauth_files)
@@ -2309,7 +2314,7 @@ def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None
         pickle_file_arg = os.path.basename(pickle_file_arg)
         post_file_arg = os.path.basename(post_file_arg)
         if os.path.exists('cal_envelopes'):
-            transfer_files += ['./cal_envelopes'] # note initial dir configured so this will work
+            transfer_files += ['../cal_envelopes'] # note initial dir configured so this will work
             ile_job.add_arg(" --use-local-cal-files ")
     ile_job.add_opt('data_dump_file', str(pickle_file_arg))
     ile_job.add_opt('posterior_sample_file', str(post_file_arg))

--- a/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
@@ -2248,7 +2248,7 @@ def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None
             if transfer_files is None:
                 transfer_files= [singularity_image]
             else:
-                transfer_files + = [singularity_image]
+                transfer_files += [singularity_image]
 
     
     exe = exe or which("calibration_reweighting.py")

--- a/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
@@ -2284,6 +2284,7 @@ def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None
         ile_job.add_condor_cmd('transfer_executable', 'False')
         ile_job.add_condor_cmd("MY.SingularityBindCVMFS", 'True')
         ile_job.add_condor_cmd("MY.SingularityImage", '"' + singularity_image_used + '"')
+        ile_job.add_condor_cmd("transfer_output_files", "weight_files")
         requirements.append("HAS_SINGULARITY=?=TRUE")
         print(" WARNING: cal reweighting requires bilby. Directories are moved to cal_evelopes")
 #        os.system("condor_config_val UID_DOMAIN > uid_domain.txt")
@@ -2314,7 +2315,7 @@ def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None
         pickle_file_arg = os.path.basename(pickle_file_arg)
         post_file_arg = os.path.basename(post_file_arg)
         if os.path.exists('cal_envelopes'):
-            transfer_files += ['../cal_envelopes'] # note initial dir configured so this will work
+            transfer_files += ['./cal_envelopes'] # note initial dir configured so this will work
             ile_job.add_arg(" --use-local-cal-files ")
     ile_job.add_opt('data_dump_file', str(pickle_file_arg))
     ile_job.add_opt('posterior_sample_file', str(post_file_arg))

--- a/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
@@ -2305,9 +2305,12 @@ def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None
     pickle_file_arg = str(pickle_file)
     post_file_arg = str(posterior_file)
     if use_osg:
-        transfer_files = pickle_file_arg + ',' + post_file_arg
+        transfer_files += [pickle_file_arg , post_file_arg]
         pickle_file_arg = os.path.basename(pickle_file_arg)
         post_file_arg = os.path.basename(post_file_arg)
+        if os.path.exists('cal_envelopes'):
+            transfer_files += ['./cal_envelopes'] # note initial dir configured so this will work
+            ile_job.add_arg(" --use-local-cal-files ")
     ile_job.add_opt('data_dump_file', str(pickle_file_arg))
     ile_job.add_opt('posterior_sample_file', str(post_file_arg))
     ile_job.add_opt('number_of_calibration_curves', str(n_cal))

--- a/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
@@ -2292,7 +2292,7 @@ def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None
 
     #
     # Add mandatory options
-    pickke_file_arg = str(pickle_file)
+    pickle_file_arg = str(pickle_file)
     post_file_arg = str(posterior_file)
     if use_osg:
         transfer_files = pickle_file_arg + ',' + post_file_arg

--- a/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
@@ -2293,7 +2293,7 @@ def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None
     #
     # Add mandatory options
     pickke_file_arg = str(pickle_file)
-    post_file_arg = str(posterior_fie)
+    post_file_arg = str(posterior_file)
     if use_osg:
         transfer_files = pickle_file_arg + ',' + post_file_arg
         pickle_file_arg = os.path.basename(pickle_file_arg)

--- a/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
@@ -701,7 +701,7 @@ def write_CIP_sub(tag='integrate', exe=None, input_net='all.net',output='output-
     return ile_job, ile_sub_name
 
 
-def write_puff_sub(tag='puffball', exe=None, input_net='output-ILE-samples',output='puffball',universe="vanilla",out_dir=None,log_dir=None, use_eos=False,ncopies=1,arg_str=None,request_memory=1024,arg_vals=None, no_grid=False,extra_text='',**kwargs):
+def write_puff_sub(tag='puffball', exe=None, base=None,input_net='output-ILE-samples',output='puffball',universe="vanilla",out_dir=None,log_dir=None, use_eos=False,ncopies=1,arg_str=None,request_memory=1024,arg_vals=None, no_grid=False,extra_text='',**kwargs):
     """
     Perform puffball calculation 
     Inputs:
@@ -711,6 +711,7 @@ def write_puff_sub(tag='puffball', exe=None, input_net='output-ILE-samples',outp
 
     exe = exe or which("util_ParameterPuffball.py")
     # Create executable if needed  (using extra_text as flag for now)
+    base_str = ''
     if len(extra_text) > 0:
         if not (base is None):
             base_str = ' ' + base +"/"
@@ -1147,6 +1148,7 @@ def write_consolidate_sub_simple(tag='consolidate', exe=None, base=None,target=N
     exe = exe or which("util_ILEdagPostprocess.sh")
 
     # Create executable if needed  (using extra_text as flag for now)
+    base_str = ''
     if len(extra_text) > 0:
         if not (base is None):
             base_str = ' ' + base +"/"

--- a/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/misc/dag_utils.py
@@ -2225,7 +2225,7 @@ def write_subdagILE_sub(tag='subdag_ile', full_path_name=True, exe=None, univers
     return ile_job, ile_sub_name
 
 
-def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None, log_dir=None, ncopies=1,request_memory=8192,time_marg=True,pickle_file=None,posterior_file=None,universe='vanilla',no_grid=False,ile_args=None,n_cal=100,use_osg=False,use_oauth_files=False,singularity_image=None,transfer_files=None,**kwargs):
+def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None, log_dir=None, ncopies=1,request_memory=8192,time_marg=True,pickle_file=None,posterior_file=None,universe='vanilla',no_grid=False,ile_args=None,n_cal=100,use_osg=False,use_oauth_files=False,use_singularity=False,singularity_image=None,transfer_files=None,**kwargs):
     """
     Write a submit file for launching jobs to reweight final posterior samples due to calibration uncertainty 
 
@@ -2234,7 +2234,22 @@ def write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight', exe=None
     Outputs:
      - reweighted samples due to calibration uncertainty and corresponding weights
     """
-    transfer_files = None
+    if use_singularity and (singularity_image == None)  :
+        print(" FAIL : Need to specify singularity_image to use singularity ")
+        sys.exit(0)
+    if use_singularity and (transfer_files == None)  :
+        print(" FAIL : Need to specify transfer_files to use singularity at present!  (we will append the prescript; you should transfer any PSDs as well as the grid file ")
+        sys.exit(0)
+
+    singularity_image_used = "{}".format(singularity_image) # make copy
+    if singularity_image:
+        if 'osdf:' in singularity_image:
+            singularity_image_used  = "./{}".format(singularity_image.split('/')[-1])
+            if transfer_files is None:
+                transfer_files= [singularity_image]
+            else:
+                transfer_files + = [singularity_image]
+
     
     exe = exe or which("calibration_reweighting.py")
     if exe is None:

--- a/MonteCarloMarginalizeCode/Code/bin/calibration_reweighting.py
+++ b/MonteCarloMarginalizeCode/Code/bin/calibration_reweighting.py
@@ -182,6 +182,9 @@ parser.add(
     "--dump_cal_realization", action='store_true',
     help="Dumps output file (in same location as weights) ")
 parser.add(
+    "--use_local_cal_files", action='store_true',
+    help="Assume cal files have been transferred to the current working directory, without name conflicts!")
+parser.add(
     "--posterior_sample_file", default=None,
     help="Bilby result file or text file with posterior samples to reweight")
 parser.add(
@@ -381,6 +384,8 @@ waveform_generator = bilby.gw.waveform_generator.WaveformGenerator(
 priors = bilby.core.prior.PriorDict()
 for ifo in ifos_for_reweighting:
     calibration_file_path = f'{spline_calibration_envelope_dict[ifo.name]}'
+    if args.use_local_cal_files:
+        calibration_file_path = './cal_envelopes/' + os.path.basename(calibration_file_path) # force local, specific name. Copied in place earlier
     ifo_calibration_priors = bilby.gw.prior.CalibrationPriorDict.from_envelope_file(
         calibration_file_path, ifo.minimum_frequency, ifo.maximum_frequency, 10, ifo.name)
 
@@ -448,7 +453,7 @@ else:
 
 # Setting up the resume and weight file names
 resume_file = None
-if (start_index != None) and (start_index != None):
+if (start_index != None) and (end_index != None):
     weights_file = f'{outdir}/weight_files/weights_s{start_index}e{end_index}.dat'
 elif start_index != None:
     weights_file = f'{outdir}/weight_files/weights_s{start_index}eNone.dat'

--- a/MonteCarloMarginalizeCode/Code/bin/combine_weights_and_rejection_sample.py
+++ b/MonteCarloMarginalizeCode/Code/bin/combine_weights_and_rejection_sample.py
@@ -35,7 +35,8 @@ def index_of(sub_str, my_list):
 saved_dtype=None
 def check_valid_import(fname):
     try:
-        dat = np.genfromtxt(fname,names=True)
+        #dat = np.genfromtxt(fname,names=True)
+        pd.read_csv(fname, sep=' ')
     except:
         return False
     return True
@@ -63,7 +64,8 @@ if have_extended:
     keys_post = [name_to_key(s) for s in fnames_extended_post if check_valid_import(s)] # key list
     v = set(keys_weights).intersection(set(keys_post)); print(v)
     keys_common = list(v) # remove duplicates
-    #print(keys_weights, keys_common, keys_post)
+    print(keys_weights, keys_common, keys_post)
+    print(len(keys_common), len(keys_weights), len(keys_post))
     indx_post    = [index_of(s, fnames_extended_post) for s in keys_common]
     indx_weights = [index_of(s, fnames_weights) for s in keys_common]
     #print(indx_post, indx_weights)
@@ -89,7 +91,7 @@ if have_extended and len(fnames_extended_post) ==len(fnames_weights):
     dtype_here=None
     dat_net = None
     for name in fnames_extended_post:
-        dat_here = np.genfromtxt(name, names=True)
+        dat_here = pd.read_csv(name,sep=' ').to_records() #np.genfromtxt(name, names=True)
         if dtype_here is None:
             dtype_here = dat_here.dtype
             dat_net = dat_here

--- a/MonteCarloMarginalizeCode/Code/bin/create_event_parameter_pipeline_BasicIteration
+++ b/MonteCarloMarginalizeCode/Code/bin/create_event_parameter_pipeline_BasicIteration
@@ -260,6 +260,7 @@ parser.add_argument("--calibration-reweighting-batchsize",type=int,default=None,
 parser.add_argument("--calibration-reweighting-initial-extra-args",type=str,default='',help="Passed to reweighting script as extra args")
 parser.add_argument("--calibration-reweighting-extra-args",type=str,default='',help="Passed to the combination script as extra arguments. ")
 parser.add_argument("--calibration-reweighting-count",type=int,default=100,help="Number of calibration marginalization realizations. Default is 100")
+parser.add_argument("--calibration-reweighting-osg",action='store_true',help="Attempt to use settings for OSG for cal reweighting. Remove after developed")
 parser.add_argument("--convert-ascii2h5-exe",default=None,help="Converting ascii to h5 file script")
 parser.add_argument("--comov-distance-reweighting-exe",default=None,help="Comoving distance reweighting script")
 parser.add_argument("--comov-distance-reweighting",action='store_true',help="Run comoving distance reweighting on final posterior samples")
@@ -1233,14 +1234,22 @@ fi;
     rotate_job.write_sub_file()
 
 if opts.calibration_reweighting:
-    if opts.last_iteration_extrinsic_time_resampling and opts.bilby_pickle_file:
-        calibration_job, calibration_job_name = dag_utils.write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight',log_dir=None,posterior_file=opts.working_directory+"/extrinsic_posterior_samples.dat",time_marg=False,pickle_file=opts.bilby_pickle_file,exe=opts.calibration_reweighting_exe,universe=local_worker_universe,no_grid=no_worker_grid,ile_args=ile_args,n_cal=opts.calibration_reweighting_count)
-    elif opts.last_iteration_extrinsic_time_resampling and opts.bilby_ini_file:
-        calibration_job, calibration_job_name = dag_utils.write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight',log_dir=None,posterior_file=opts.working_directory+"/extrinsic_posterior_samples.dat",time_marg=False,pickle_file=opts.working_directory+"/calmarg/data/calmarg_data_dump.pickle",exe=opts.calibration_reweighting_exe,universe=local_worker_universe,no_grid=no_worker_grid,ile_args=ile_args,n_cal=opts.calibration_reweighting_count)
-    elif (not opts.last_iteration_extrinsic_time_resampling) and opts.bilby_ini_file:
-        calibration_job, calibration_job_name = dag_utils.write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight',log_dir=None,posterior_file=opts.working_directory+"/extrinsic_posterior_samples.dat",time_marg=True,pickle_file=opts.working_directory+"/calmarg/data/calmarg_data_dump.pickle",exe=opts.calibration_reweighting_exe,universe=local_worker_universe,no_grid=no_worker_grid,ile_args=ile_args,n_cal=opts.calibration_reweighting_count)
-    elif (not opts.last_iteration_extrinsic_time_resampling) and opts.bilby_pickle_file:
-        calibration_job, calibration_job_name = dag_utils.write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight',log_dir=None,posterior_file=opts.working_directory+"/extrinsic_posterior_samples.dat",time_marg=True,pickle_file=opts.bilby_pickle_file,exe=opts.calibration_reweighting_exe,universe=local_worker_universe,no_grid=no_worker_grid,ile_args=ile_args,n_cal=opts.calibration_reweighting_count)
+    extra_args_dict = {}
+    extra_args_dict['time_marg'] = not (opts.last_iteration_extrinsic)   # pass time_marg=False if we are resampling in time
+    if opts.bilby_pickle_file:
+        extra_args_dict['pickle_file'] = opts.bilby_pickle_file
+    else:
+        extra_args_dict['pickle_file'] =opts.working_directory+"/calmarg/data/calmarg_data_dump.pickle"
+    # OSG options
+    if opts.calibration_reweighting_osg:
+        extra_args_dict['use_osg'] =  opts.use_osg
+        extra_args_dict['use_singularity'] =  opts.use_singularity
+    if opts.transfer_file_list:
+        # Handle scenario where h5 file needed by calmarg job. Note arranged as transfer because we don't know if execute nodes have the file, even if local
+        any_h5_needed_list = [x for x in transfer_file_names if x.endswith('.h5')]  # NRSur, etc h5 files we need for lalsuite
+        extra_args_dict['transfer_files'] = any_h5_needed_list
+        
+    calibration_job, calibration_job_name = dag_utils.write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight',log_dir=None,posterior_file=opts.working_directory+"/extrinsic_posterior_samples.dat",exe=opts.calibration_reweighting_exe,universe=local_worker_universe,no_grid=no_worker_grid,ile_args=ile_args,n_cal=opts.calibration_reweighting_count, **extra_args_dict)
         
     if opts.calibration_reweighting_initial_extra_args:
         # properly handle quoted extra arguments, such as dictionaries of waveform arguments
@@ -1264,16 +1273,6 @@ if opts.calibration_reweighting:
     if opts.use_full_submit_paths:
         fname = opts.working_directory+"/"+calibration_job.get_sub_file()
         calibration_job.set_sub_file(fname)
-    if opts.transfer_file_list:
-        # Handle scenario where h5 file needed by calmarg job. Note arranged as transfer because we don't know if execute nodes have the file, even if local
-        any_h5_needed_list = [x for x in transfer_file_names if x.endswith('.h5')]  # NRSur, etc h5 files we need for lalsuite
-        if len(any_h5_needed_list)>0:
-            fname_str = ','.join(any_h5_needed_list)
-            fname_str = fname_str.strip()
-            calibration_job.add_condor_cmd('transfer_input_files',fname_str)
-            calibration_job.add_condor_cmd('should_transfer_files','YES')
-            if 'osdf:' in fname_str and opts.use_oauth_files:
-                calibration_job.add_condor_cmd('use_oauth_services', opts.use_oauth_files)  # add scitokens
     calibration_job.write_sub_file()
 
     # job to combine things. Write here to make logic human-readable

--- a/MonteCarloMarginalizeCode/Code/bin/create_event_parameter_pipeline_BasicIteration
+++ b/MonteCarloMarginalizeCode/Code/bin/create_event_parameter_pipeline_BasicIteration
@@ -1244,12 +1244,17 @@ if opts.calibration_reweighting:
     if opts.calibration_reweighting_osg:
         extra_args_dict['use_osg'] =  opts.use_osg
         extra_args_dict['use_singularity'] =  opts.use_singularity
+        extra_args_dict['singularity_image'] = singularity_image
+        extra_args['universe'] = vanilla
+    else:
+        extra_args['no_grid']  = no_worker_grid
+        extra_args['universe'] = local_worker_universe
     if opts.transfer_file_list:
         # Handle scenario where h5 file needed by calmarg job. Note arranged as transfer because we don't know if execute nodes have the file, even if local
         any_h5_needed_list = [x for x in transfer_file_names if x.endswith('.h5')]  # NRSur, etc h5 files we need for lalsuite
         extra_args_dict['transfer_files'] = any_h5_needed_list
         
-    calibration_job, calibration_job_name = dag_utils.write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight',log_dir=None,posterior_file=opts.working_directory+"/extrinsic_posterior_samples.dat",exe=opts.calibration_reweighting_exe,universe=local_worker_universe,no_grid=no_worker_grid,ile_args=ile_args,n_cal=opts.calibration_reweighting_count, **extra_args_dict)
+    calibration_job, calibration_job_name = dag_utils.write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight',log_dir=None,posterior_file=opts.working_directory+"/extrinsic_posterior_samples.dat",exe=opts.calibration_reweighting_exe,ile_args=ile_args,n_cal=opts.calibration_reweighting_count, **extra_args_dict)
         
     if opts.calibration_reweighting_initial_extra_args:
         # properly handle quoted extra arguments, such as dictionaries of waveform arguments
@@ -1268,7 +1273,10 @@ if opts.calibration_reweighting:
         calibration_job.set_log_file(opts.working_directory+"/calmarg/logs/calibration-$(macrostartidx)-$(cluster)-$(process).log")
         calibration_job.set_stderr_file(opts.working_directory+"/calmarg/logs/calibration-$(macrostartidx)-$(cluster)-$(process).err")
         calibration_job.set_stdout_file(opts.working_directory+"/calmarg/logs/calibration-$(macrostartidx)-$(cluster)-$(process).out")
-    calibration_job.add_condor_cmd('request_disk',opts.general_request_disk)
+    if opts.use_singularity and opts.calibration_reweighting_osg:
+        calibration_job.add_condor_cmd('request_disk',opts.ile_request_disk)  # similar task, so use similar request
+    else:
+        calibration_job.add_condor_cmd('request_disk',opts.general_request_disk)
 
     if opts.use_full_submit_paths:
         fname = opts.working_directory+"/"+calibration_job.get_sub_file()

--- a/MonteCarloMarginalizeCode/Code/bin/create_event_parameter_pipeline_BasicIteration
+++ b/MonteCarloMarginalizeCode/Code/bin/create_event_parameter_pipeline_BasicIteration
@@ -1254,7 +1254,7 @@ if opts.calibration_reweighting:
         any_h5_needed_list = [x for x in transfer_file_names if x.endswith('.h5')]  # NRSur, etc h5 files we need for lalsuite
         extra_args_dict['transfer_files'] = any_h5_needed_list
         
-    calibration_job, calibration_job_name = dag_utils.write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight',log_dir=None,posterior_file=opts.working_directory+"/extrinsic_posterior_samples.dat",exe=opts.calibration_reweighting_exe,ile_args=ile_args,n_cal=opts.calibration_reweighting_count, **extra_args_dict)
+    calibration_job, calibration_job_name = dag_utils.write_calibration_uncertainty_reweighting_sub(tag='Calib_reweight',log_dir=None,posterior_file=opts.working_directory+"/extrinsic_posterior_samples.dat",exe=opts.calibration_reweighting_exe,ile_args=ile_args,n_cal=opts.calibration_reweighting_count,use_oauth_files=opts.use_oauth_files,**extra_args_dict)
         
     if opts.calibration_reweighting_initial_extra_args:
         # properly handle quoted extra arguments, such as dictionaries of waveform arguments

--- a/MonteCarloMarginalizeCode/Code/bin/create_event_parameter_pipeline_BasicIteration
+++ b/MonteCarloMarginalizeCode/Code/bin/create_event_parameter_pipeline_BasicIteration
@@ -1245,10 +1245,10 @@ if opts.calibration_reweighting:
         extra_args_dict['use_osg'] =  opts.use_osg
         extra_args_dict['use_singularity'] =  opts.use_singularity
         extra_args_dict['singularity_image'] = singularity_image
-        extra_args['universe'] = vanilla
+        extra_args_dict['universe'] = 'vanilla'
     else:
-        extra_args['no_grid']  = no_worker_grid
-        extra_args['universe'] = local_worker_universe
+        extra_args_dict['no_grid']  = no_worker_grid
+        extra_args_dict['universe'] = local_worker_universe
     if opts.transfer_file_list:
         # Handle scenario where h5 file needed by calmarg job. Note arranged as transfer because we don't know if execute nodes have the file, even if local
         any_h5_needed_list = [x for x in transfer_file_names if x.endswith('.h5')]  # NRSur, etc h5 files we need for lalsuite

--- a/MonteCarloMarginalizeCode/Code/bin/create_event_parameter_pipeline_BasicIteration
+++ b/MonteCarloMarginalizeCode/Code/bin/create_event_parameter_pipeline_BasicIteration
@@ -1267,7 +1267,10 @@ if opts.calibration_reweighting:
         calibration_job.set_stderr_file(opts.working_directory+"/calmarg/logs/calibration-$(cluster)-$(process).err")
         calibration_job.set_stdout_file(opts.working_directory+"/calmarg/logs/calibration-$(cluster)-$(process).out")
     else:
-        calibration_job.add_condor_cmd("initialdir",opts.working_directory+"/calmarg/")
+        if not(opts.calibration_reweighting_osg):
+            calibration_job.add_condor_cmd("initialdir",opts.working_directory+"/calmarg/")
+        else:
+            calibration_job.add_condor_cmd("initialdir",opts.working_directory)            
         calibration_job.add_arg(" --start_index $(macrostartidx) ")
         calibration_job.add_arg(" --end_index $(macroendidx) ")
         calibration_job.set_log_file(opts.working_directory+"/calmarg/logs/calibration-$(macrostartidx)-$(cluster)-$(process).log")

--- a/MonteCarloMarginalizeCode/Code/bin/util_RIFT_pseudo_pipe.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_RIFT_pseudo_pipe.py
@@ -151,6 +151,7 @@ parser.add_argument("--calibration-reweighting-batchsize",type=int,default=None,
 parser.add_argument("--calibration-reweighting-count",type=int,default=None,help="If not 'None', the number of calibration curves to request when marginalizing. Default is 100")
 parser.add_argument("--calibration-reweighting-initial-extra-args",type=str,default=None,help="If not 'None', pass through. One argument targets effective sample size, other duplicates inoutput")
 parser.add_argument("--calibration-reweighting-extra-args",type=str,default=None,help="If not 'None', pass through. One argument targets effective sample size, other duplicates inoutput")
+parser.add_argument("--calibration-reweighting-osg",action='store_true',help="Attempt to use settings for OSG for cal reweighting. Remove after developed")
 parser.add_argument("--distance-reweighting",action='store_true',help="Option to add job to DAG to reweight posterior samples due to different distance prior (LVK prod prior)")
 parser.add_argument("--extra-args-helper",action=None, help="Filename with arguments for the helper. Use to provide alternative channel names and other advanced configuration (--channel-name, data type)!")
 parser.add_argument("--manual-postfix",default='',type=str)

--- a/MonteCarloMarginalizeCode/Code/bin/util_RIFT_pseudo_pipe.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_RIFT_pseudo_pipe.py
@@ -1418,20 +1418,22 @@ if opts.calibration_reweighting and (not opts.bilby_pickle_file):
         cmd += " --calibration-reweighting-batchsize {} ".format(opts.calibration_reweighting_batchsize)
     if opts.calibration_reweighting_extra_args:
         cmd += " --calibration-reweighting-extra-args '{}' ".format(opts.calibration_reweighting_extra_args)
-    if opts.calibration_reweighting_initial_extra_args:
-        cmd += " --calibration-reweighting-initial-extra-args '{}' ".format(opts.calibration_reweighting_initial_extra_args)
     if opts.calibration_reweighting_osg:
         cmd += " --calibration-reweighting-osg "
+        opts.calibration_reweighting_intial_extra_args += " --local_cal_files "
+    if opts.calibration_reweighting_initial_extra_args:
+        cmd += " --calibration-reweighting-initial-extra-args '{}' ".format(opts.calibration_reweighting_initial_extra_args)
 elif opts.calibration_reweighting and opts.bilby_pickle_file:
     cmd += " --calibration-reweighting --calibration-reweighting-exe `which calibration_reweighting.py` --bilby-pickle-file {} ".format(str(opts.bilby_pickle_file))
     if opts.calibration_reweighting_count:
         cmd+= " --calibration-reweighting-count {} ".format(opts.calibration_reweighting_count)
     if opts.calibration_reweighting_extra_args:
         cmd += " --calibration-reweighting-extra-args '{}' ".format(opts.calibration_reweighting_extra_args)
-    if opts.calibration_reweighting_initial_extra_args:
-        cmd += " --calibration-reweighting-initial-extra-args '{}' ".format(opts.calibration_reweighting_initial_extra_args)
     if opts.calibration_reweighting_osg:
         cmd += " --calibration-reweighting-osg "
+        opts.calibration_reweighting_intial_extra_args += " --local_cal_files "
+    if opts.calibration_reweighting_initial_extra_args:
+        cmd += " --calibration-reweighting-initial-extra-args '{}' ".format(opts.calibration_reweighting_initial_extra_args)
 if opts.internal_tabular_eos_file:
     cmd += " --use-tabular-eos-file "
 if opts.distance_reweighting:

--- a/MonteCarloMarginalizeCode/Code/bin/util_RIFT_pseudo_pipe.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_RIFT_pseudo_pipe.py
@@ -1419,6 +1419,8 @@ if opts.calibration_reweighting and (not opts.bilby_pickle_file):
         cmd += " --calibration-reweighting-extra-args '{}' ".format(opts.calibration_reweighting_extra_args)
     if opts.calibration_reweighting_initial_extra_args:
         cmd += " --calibration-reweighting-initial-extra-args '{}' ".format(opts.calibration_reweighting_initial_extra_args)
+    if opts.calibration_reweighting_osg:
+        cmd += " --calibration-reweighting-osg "
 elif opts.calibration_reweighting and opts.bilby_pickle_file:
     cmd += " --calibration-reweighting --calibration-reweighting-exe `which calibration_reweighting.py` --bilby-pickle-file {} ".format(str(opts.bilby_pickle_file))
     if opts.calibration_reweighting_count:
@@ -1427,6 +1429,8 @@ elif opts.calibration_reweighting and opts.bilby_pickle_file:
         cmd += " --calibration-reweighting-extra-args '{}' ".format(opts.calibration_reweighting_extra_args)
     if opts.calibration_reweighting_initial_extra_args:
         cmd += " --calibration-reweighting-initial-extra-args '{}' ".format(opts.calibration_reweighting_initial_extra_args)
+    if opts.calibration_reweighting_osg:
+        cmd += " --calibration-reweighting-osg "
 if opts.internal_tabular_eos_file:
     cmd += " --use-tabular-eos-file "
 if opts.distance_reweighting:


### PR DESCRIPTION
Changes to enable calibration marginalization to work with containers, via ``--calibration-reweighting-osg`` pipeline argument. Key features
* cal_envelopes: local copies of cal envelopes, transferred to remote hosts
* containerization basics: executable in container, transfer container and pickle