### PR TITLE
Misc changes 1

### DIFF
--- a/MonteCarloMarginalizeCode/Code/RIFT/lalsimutils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/lalsimutils.py
@@ -3661,7 +3661,7 @@ def hlmoft(P, Lmax=2,nr_polarization_convention=False, fixed_tapering=False, sil
     approx_string = P.approx
     if not(isinstance(approx_string,str)):
         approx_string = lalsim.GetStringFromApproximant(approx_string)
-    if 'NRSur' in approx_string:
+    if 'NRSur' in approx_string or 'NRHyb' in approx_string:
         # some NRSur are aligned only and return only m>=0 modes, so reflect IF NEEDED
         mode_keys = np.array([[l,m] for l,m in hlm_dict.keys()])[:,1]
         check_if_only_positive_m = not((mode_keys < 0).any())

--- a/MonteCarloMarginalizeCode/Code/bin/helper_LDG_Events.py
+++ b/MonteCarloMarginalizeCode/Code/bin/helper_LDG_Events.py
@@ -1718,15 +1718,12 @@ with open("helper_cip_args.txt",'w') as f:
 
 
 if opts.propose_flat_strategy:
-    # All iterations of CIP use the same as the last
-    instructions_cip = map(lambda x: x.rstrip().split(' '), helper_cip_arg_list)#np.loadtxt("helper_cip_arg_list.txt", dtype=str)
-    n_iterations =0
-    lines  = []
-    for indx in np.arange(len(instructions_cip)):
-        n_iterations += int(instructions_cip[indx][0])
-        lines.append(' '.join(instructions_cip[indx][1:]))   # merge back together
-    helper_cip_arg_list  = [str(n_iterations) + " " + lines[-1]]  # overwrite with new setup
+    instructions_cip = [line.rstrip().split() for line in helper_cip_arg_list]
 
+    n_iterations = sum(int(instr[0]) for instr in instructions_cip)
+    last_line = " ".join(instructions_cip[-1][1:])
+
+    helper_cip_arg_list = [f"{n_iterations} {last_line}"]
 
 if opts.propose_converge_last_stage:
     helper_cip_last_it = '1 ' +  ' '.join(helper_cip_arg_list[-1].split()[1:])

--- a/MonteCarloMarginalizeCode/Code/bin/util_RIFT_pseudo_pipe.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_RIFT_pseudo_pipe.py
@@ -330,7 +330,7 @@ parser.add_argument("--use-osg-public",action='store_true',help="Activate public
 parser.add_argument("--archive-pesummary-label",default=None,help="If provided, creates a 'pesummary' directory and fills it with this run's final output at the end of the run")
 parser.add_argument("--archive-pesummary-event-label",default="this_event",help="Label to use on the pesummary page itself")
 parser.add_argument("--internal-mitigate-fd-J-frame",default="L_frame",help="L_frame|rotate, choose method to deal with ChooseFDWaveform being in wrong frame. Default is to request L frame for inputs")
-parser.add_argument("--internal-force-puff-iterations", default=4, type=int, type=int, help="Number of iterations to be puffed")
+parser.add_argument("--internal-force-puff-iterations", default=4, type=int, help="Number of iterations to be puffed")
 opts=  parser.parse_args()
 
 config_stored=None; config_dict=None

--- a/MonteCarloMarginalizeCode/Code/bin/util_RIFT_pseudo_pipe.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_RIFT_pseudo_pipe.py
@@ -330,6 +330,7 @@ parser.add_argument("--use-osg-public",action='store_true',help="Activate public
 parser.add_argument("--archive-pesummary-label",default=None,help="If provided, creates a 'pesummary' directory and fills it with this run's final output at the end of the run")
 parser.add_argument("--archive-pesummary-event-label",default="this_event",help="Label to use on the pesummary page itself")
 parser.add_argument("--internal-mitigate-fd-J-frame",default="L_frame",help="L_frame|rotate, choose method to deal with ChooseFDWaveform being in wrong frame. Default is to request L frame for inputs")
+parser.add_argument("--internal-force-puff-iterations", default=4, type=int, type=int, help="Number of iterations to be puffed")
 opts=  parser.parse_args()
 
 config_stored=None; config_dict=None
@@ -1329,7 +1330,7 @@ with open("args_cip_list.txt",'w') as f:
 
 # Write puff file
 #puff_params = " --parameter mc --parameter delta_mc --parameter chieff_aligned "
-puff_max_it =4
+puff_max_it = opts.internal_force_puff_iterations
 #  Read puff args from file, if present
 try:
     with open("helper_puff_max_it.txt",'r') as f:


### PR DESCRIPTION
Minor changes to util_RIFT_pseudo_pipe.py, helper_LDG_Events.py, and lalsimutils.py. 
util_RIFT_pseudo_pipe.py: allow users to provide the number of iterations to puff using the option internal-force-puff-iterations, and it defaults back to the original hardcoded value of 4.
helper_LDG_Events.py: fixed the bug in this code when using --propose-flat-strategy. Tested for the basic iteration setup.
lalsimutils.py: Inference using NRHybsur3dq8 (lalsimulation version) fails as they do not provide negative m modes, but are needed. This now utilizes the existing code block for producing negative m modes for NRHybSur3dq8, which was originally meant for NRSur approximants.