### PR TITLE
lalsimutils: fix spurious (l,±m) asymmetry in hlmoft FD-mode conditioning

### DIFF
--- a/MonteCarloMarginalizeCode/Code/RIFT/lalsimutils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/lalsimutils.py
@@ -3275,7 +3275,11 @@ def hlmoft(P, Lmax=2,nr_polarization_convention=False, fixed_tapering=False, sil
        # but that is very difficult to do because modes of different 'm' and thus typical frequency generally mix
        # Note also that unless the segment length is large, this is often surprisingly few frequency bins for tapering
        if not(no_condition):
-           our_fvals = evaluate_fvals(hlmsdict[(2,2)])
+           # lal_convention=True is REQUIRED here: ChooseFDModes returns the ascending
+           # center-DC grid, and the default (RIFT reversed) convention would shift the
+           # high-pass window by one bin between (l,m) and (l,-m), breaking the
+           # conjugate-pair identity at the percent level.  See evaluate_fvals docs.
+           our_fvals = evaluate_fvals(hlmsdict[(2,2)], lal_convention=True)
            vectaper_symmetric  = np.ones(len(our_fvals))
            indx_below = np.logical_and(np.abs(our_fvals)<P.fmin, np.abs(our_fvals)>=P.fmin*fd_standoff_factor)
            vectaper_symmetric[indx_below] = 0.5 + 0.5*np.cos(np.pi* (np.abs(our_fvals[indx_below])/P.fmin - 1)/(1-fd_standoff_factor))
@@ -3300,7 +3304,15 @@ def hlmoft(P, Lmax=2,nr_polarization_convention=False, fixed_tapering=False, sil
            indx_crit = TDlen - ntaper
 
        for mode in hlmsdict:
+          npts_fd_pre_resize = hlmsdict[mode].data.length
           hlmsdict[mode] = lal.ResizeCOMPLEX16FrequencySeries(hlmsdict[mode],0, TDlen)
+          if npts_fd_pre_resize > TDlen:
+              # The resize above truncated the +fNyq bin from the two-sided grid but kept
+              # its -fNyq partner (index 0).  Zero it so the truncation commutes with the
+              # conjugate-pair (f -> -f) reflection for models with support at Nyquist.
+              # Tied to the truncation itself, NOT to no_condition: an asymmetric
+              # truncation would reintroduce (l,±m) asymmetry even on the raw path.
+              hlmsdict[mode].data.data[0] = 0
           hlmsT[mode] = DataInverseFourier(hlmsdict[mode])
           # Phase factors: see crazy conventions in https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalsimulation/lib/LALSimInspiral.c
           if True: #P.approx == lalIMRPhenomXHM or P.approx == lalIMRPhenomHM:
@@ -4901,12 +4913,25 @@ def psd_windowing_factor(window_shape, TDlen):
 def evaluate_tvals(lal_tseries):
     return float(lal_tseries.epoch) +lal_tseries.deltaT*np.arange(lal_tseries.data.length)
 
-def evaluate_fvals(lal_2sided_fseries):
+def evaluate_fvals(lal_2sided_fseries, lal_convention=False):
     r"""
-    evaluate_fvals(lal_2sided_fseries)
+    evaluate_fvals(lal_2sided_fseries, lal_convention=False)
     Associates frequencies with a 2sided lal complex array.  Compare with 'self.longweights' code
     Done by HAND in PrecessingOrbitModesOfFrequency
     Manually *reverses* convention re sign of \omega used in lal!
+
+    lal_convention=False (default): RIFT's own two-sided packing (arrays produced by
+       DataFourier/complex_hoff): even length, REVERSED, f[k] = deltaF*(npts/2 - k).
+       WARNING: for odd-length arrays this assigns f on a grid offset by deltaF/2 --
+       it is only correct for the even-length RIFT packing.
+    lal_convention=True: the packing of two-sided series returned directly by LAL
+       generators (e.g. SimInspiralChooseFDModes): ASCENDING [-fNyq, ..., 0, ..., +fNyq]
+       with DC at index npts//2 (odd length TDlen+1; even length after truncation keeps
+       DC at npts//2).  f[k] = deltaF*(k - npts//2), exact for both parities of npts.
+       Use this - not the default - on ChooseFDModes output: the default's reversal +
+       half-bin offset shifts any |f|-symmetric window by one bin between (l,m) and
+       (l,-m) modes (which live at opposite signs of f), breaking the conjugate-pair
+       identity h_{l,-m}(f) = (-1)^l conj(h_{lm}(-f)) at the percent level.
 
     Notes:
        a) XXXFrequencySeries  have an f0 and a deltaF, and *logically* they should run from f0....f0+N*df
@@ -4939,6 +4964,8 @@ def evaluate_fvals(lal_2sided_fseries):
     """
     npts = lal_2sided_fseries.data.length
     df = lal_2sided_fseries.deltaF
+    if lal_convention:
+        return df*(np.arange(npts) - npts//2)
     fvals = np.zeros(npts)
     # https://www.lsc-group.phys.uwm.edu/daswg/projects/lal/nightly/docs/html/group___time_freq_f_f_t__h.html
     # https://www.lsc-group.phys.uwm.edu/daswg/projects/lal/nightly/docs/html/_time_freq_f_f_t_8h.html


### PR DESCRIPTION
Single-commit replacement for #162 (which accidentally carried the whole development-branch history; closing it in favor of this).

## Summary

RIFT's `hlmoft` ChooseFDModes→TD conditioning introduced spurious (±m) mode asymmetry at the ~1% level for every ChooseFDModes-consumed model (IMRPhenomXHM/XPHM/XPNR/XO4a/HM): an exactly-symmetric aligned-spin IMRPhenomXHM input acquired 1.02% (2,±2) and 0.9% (3,±3) relative amplitude asymmetry, violating the conjugate-pair identity `h_{l,-m}(f) = (-1)^l conj(h_{lm}(-f))`.

**Root cause:** `SimInspiralChooseFDModes` returns modes on an ascending two-sided grid [−fNyq, +fNyq] with DC at the center index (odd length TDlen+1), but the FD high-pass window assigned frequencies via `evaluate_fvals`, which assumes RIFT's reversed packing and, at odd length, gives `f_assumed = −f_true + deltaF/2`. Since (l,m) and (l,−m) modes occupy opposite signs of f, the nominally |f|-symmetric window landed one bin apart on the two members of each pair — precisely in the taper band [0.964·fmin, fmin] containing the |h̃(f)| maximum.

**Fix:** build the window on the true frequency grid (`P.deltaF*(np.arange(npts) - npts//2)`, exactly even in f), and zero the −fNyq bin left unpaired when the resize truncates its +fNyq partner, so all conditioning commutes with complex conjugation. All other conditioning stages (start/end tapers, centering roll, IFFT) are covariant already.

## Verification

Nonprec control (m1=44, m2=36 Msun, s1z=0.5, s2z=−0.3, fmin=fref=20, deltaF=1/16, deltaT=1/4096), rerun against this branch (master + this commit):

- Raw ChooseFDModes XHM satisfies the conjugate-pair identity exactly (0.0); through `hlmoft` the mode-level residual drops **1.02e-2 → 2.5e-16**. IMRPhenomHM and XPNR machine-exact; XPHM reduced to its intrinsic 4.4e-3 (2,±1) aligned-spin model asymmetry; precessing XPHM amplitude identity at 4.2e-16.
- U/V-level diagnostics: D2 **1.04e-9 → 1.28e-17**, D3 1.7e-9 → 1.4e-16. (The corrupted band lies mostly below fmin, so the U/V-level leakage was ~1e-9, not the mode-level 1e-2; the fix removes the interface floor entirely.)
- Conditioned-waveform change: 1.1e-2 full-band, 99% of it below fmin in the discarded turn-on band; 1.6e-3 in-band (corrected window-edge placement at fmin).

The parity QA scripts used for verification live on the fork's `rift_O4d` branch under `MonteCarloMarginalizeCode/Code/test/waveforms/` (merged there via oshaughnessy-junior/research-projects-RIT#52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)