### PR TITLE
util_RandomizeOverlapOrder: interleave across worker files (ILE was seeing only 4 of 25 workers)

### DIFF
--- a/MonteCarloMarginalizeCode/Code/bin/util_RandomizeOverlapOrder.py
+++ b/MonteCarloMarginalizeCode/Code/bin/util_RandomizeOverlapOrder.py
@@ -28,6 +28,7 @@ optp = OptionParser()
 optp.add_option("--fref",default=20,type=float,help="Reference frequency. Depending on approximant and age of implementation, may be ignored")
 optp.add_option("--n-min",default=20,type=int,help="Minimum size of file to include. NOT USED")
 optp.add_option("--output-file",default='merged_output',type=str,help="Merged output file")
+optp.add_option("--preserve-block-order",action='store_true',help="Do NOT interleave across input files; append each file's block in file order. This is the pre-2026-08 behaviour and is only for reproducing runs made before the interleave fix.")
 optp.add_option("--verbose",action='store_true',help="Print messages")
 opts, args = optp.parse_args()
 
@@ -60,5 +61,15 @@ for indx in np.arange(len(P_list_list)):
     indx_to_take = np.random.choice(np.arange(len(P_list_list[indx])),size=n_min,replace=False) # do not take duplicate entries from any file. Files may be small!
     P_to_add = [P_list_list[indx][a] for a in indx_to_take]
     P_list += P_to_add
+
+# Interleave ACROSS files.  The draw above randomises only WITHIN each file, and the blocks are
+# appended in file order, so the merged output is [file0][file1]...[fileN].  That is invisible to a
+# consumer that reads the whole file, but the nested ILE reads only a PREFIX (measured: the first
+# 3000 rows), so it saw just the first few workers -- with 25 workers x 800, four of them, and with
+# 6 x 3334, only the first.  That is precisely the "accidentally using only the output from one of
+# them" failure this tool exists to prevent.  The hyperpipeline branch of write_joingrids_sub
+# already does this ("shuffle so spokes are interleaved"); this brings the XML path into line.
+if not opts.preserve_block_order:
+    P_list = [P_list[k] for k in np.random.permutation(len(P_list))]
 
 lalsimutils.ChooseWaveformParams_array_to_xml(P_list,opts.output_file)


### PR DESCRIPTION
`util_RandomizeOverlapOrder.py` randomises **within** each worker file but not **across** them, so
the merged grid is `[worker0][worker1]...[workerN]`. Any consumer that reads the whole file is
unaffected. The nested ILE reads a **prefix**, so it has been evaluating only the first few workers'
proposals.

Measured on a live a placeholder event run (25 CIP workers x 800 points, merged to 20,000 rows):

| | rows | contiguous same-worker runs | workers reaching rows 0-2999 |
|---|---|---|---|
| before | 20,000 | **25** | **4 of 25** |
| after | 20,000 | 19,248 | **25 of 25** |

ILE evaluated rows 0-2999 and nothing beyond, so **21 of 25 workers contributed nothing** to the
likelihood evaluations while costing full CIP time. At the more common 6 workers x 3334 the entire
3000-row prefix sits inside **worker 0** — a single worker's proposal drives the iteration.

This is the failure the file header already warns about:

> Important when merging files from many workers, to avoid accidentally using only the output from one of them.

### Why this is alignment, not new policy

The hyperpipeline branch of `write_joingrids_sub` already does this, concatenating every shard and
piping through `shuf`, with the comment *"shuffle so spokes are interleaved"*. Only the XML path
was missing it. This brings the two merge paths into agreement.

### The change

One line — permute `P_list` across files before writing. `--preserve-block-order` restores the old
behaviour exactly, for reproducing earlier runs.

Verified on 25 real worker files: **row count unchanged, no duplicates introduced**, and the legacy
flag reproduces the previous output structure exactly (25 runs, 4 workers in the prefix).

### Impact on existing results

This changes which points get evaluated in every iteration of every run on the XML path, so results
will shift. That is the point — but it means in-flight runs should be pinned with
`--preserve-block-order` if they need to stay self-consistent, and any A/B should be against a
matched-ordering control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)