### PR TITLE
portfolio: make the driver fail loudly instead of silently substituting a sampler (driver-side complement to #168)

### DIFF
--- a/MonteCarloMarginalizeCode/Code/bin/integrate_likelihood_extrinsic_batchmode
+++ b/MonteCarloMarginalizeCode/Code/bin/integrate_likelihood_extrinsic_batchmode
@@ -287,7 +287,7 @@ integration_params.add_option("--manual-logarithm-offset",type=float,default=0,h
 integration_params.add_option("--auto-logarithm-offset",action='store_true',help="Use the 'guess_snr' field returned in the precompute stage to change --manual-logarithm-offset for each event.")
 integration_params.add_option("--internal-use-lnL",action='store_true',help="likelihood returns lnL, and integrator integrates lnL")
 integration_params.add_option("--sampler-method",default="adaptive_cartesian_gpu",help="adaptive_cartesian|GMM|adaptive_cartesian_gpu")
-integration_params.add_option("--sampler-portfolio",default=None,action='append',type=str,help="comma-separated strings, matching sampler methods other than portfolio")
+integration_params.add_option("--sampler-portfolio",default=None,action='append',type=str,help="Portfolio member sampler, one of AV / GMM / AC (adaptive_cartesian_gpu) or a discovered plugin. Repeat the option per member, or give one comma-separated list; both forms may be mixed. An unrecognized name is an error.")
 integration_params.add_option("--sampler-portfolio-args",default=None, action='append', type=str, help='eval-able dictionaryo to be passed to that sampler')
 integration_params.add_option("--sampler-xpy",default=None,help="numpy|cupy  if the adaptive_cartesian_gpu sampler is active, use that.")
 integration_params.add_option("--supplementary-likelihood-factor-code", default=None,type=str,help="Import a module (in your pythonpath!) containing a supplementary factor for the likelihood.  Used to impose supplementary external priors of arbitrary complexity and external dependence (e.g., EM observations). EXPERTS-ONLY")
@@ -804,13 +804,25 @@ elif opts.sampler_method == 'AV':
       mcsampler.set_xpy_to_numpy()
       sampler.xpy= numpy
       sampler.identity_convert= lambda x: x
-elif opts.sampler_method == "portfolio" and mcsampler_Portfolio_ok:
+elif opts.sampler_method == "portfolio":
+    # NB the `and mcsampler_Portfolio_ok` that used to be part of this test made the raise
+    # below dead code AND sent an unavailable portfolio to the `else` fallback at the end of
+    # this chain, which silently runs the plain mcsampler.MCSampler instead.  Requesting a
+    # sampler that cannot be built must fail, not quietly become a different sampler.
     if not(mcsampler_Portfolio_ok):
       raise Exception(" Portfolio integrator requested but not available")
     use_portfolio=True
     opts.internal_use_lnL=True  # required, we only implement those scenarios right now
     sampler_list = []
-    sampler_types = opts.sampler_portfolio
+    # The option is action='append', but its help has always documented a comma-separated
+    # list.  Accept both (and a mix), because the undocumented half silently misbehaved:
+    # '--sampler-portfolio AV,GMM' arrived as the single member name "AV,GMM", matched no
+    # branch in the loop below, and -- the loop having no else -- appended whatever `sampler`
+    # happened to hold, i.e. the plain MCSampler constructed before this chain.  The run then
+    # died later and elsewhere with a misleading "no attribute 'draw_simplified'".
+    sampler_types = [_n.strip() for _entry in (opts.sampler_portfolio or []) for _n in str(_entry).split(',') if _n.strip()]
+    if not sampler_types:
+      raise Exception(" --sampler-method portfolio requires at least one --sampler-portfolio member")
 
     # prep xpy, etc
     my_xpy = xpy_default
@@ -835,6 +847,12 @@ elif opts.sampler_method == "portfolio" and mcsampler_Portfolio_ok:
             mcsampler  = mcsamplerGPU  # force use of routines in that file, for properly configured GPU-accelerated code as needed
         elif name in mcsamplerPortfolio.known_pipelines:  # everything else, including nflow
             sampler =  mcsamplerPortfolio.known_pipelines[name]()
+        else:
+            # No else clause here meant an unrecognized name left `sampler` bound to its
+            # previous value -- the plain MCSampler built before this chain, or, on the second
+            # and later iterations, the PREVIOUS member -- and appended it silently.  The
+            # portfolio then ran with a member the user never asked for.
+            raise Exception(" --sampler-portfolio: unknown member '{}'.  Known: AV, GMM, AC/adaptive_cartesian_gpu, {}".format(name, sorted(mcsamplerPortfolio.known_pipelines)))
         print('PORTFOLIO: adding {} '.format(name))
         # enable xpy for low level sampler as needed 
         if hasattr(sampler, 'xpy'):
@@ -847,7 +865,7 @@ elif opts.sampler_method == "portfolio" and mcsampler_Portfolio_ok:
     sampler.identity_convert= my_identity_convert
     sampler.identity_convert_togpu= my_identity_convert_togpu
     # sampler weights will be CPU-typed, so don't change them
-elif opts.sampler_method in mcsamplerPortfolio.known_pipelines: # access from plugins
+elif mcsampler_Portfolio_ok and opts.sampler_method in mcsamplerPortfolio.known_pipelines: # access from plugins
   sampler = mcsamplerPortfolio.known_pipelines[opts.sampler_method]()
   # prep xpy, etc
   my_xpy = xpy_default
@@ -858,7 +876,10 @@ elif opts.sampler_method in mcsamplerPortfolio.known_pipelines: # access from pl
   sampler.identity_convert_togpu= my_identity_convert_togpu
 else:
     print(" ILE: **original sampler** ")
-    print(" ILE requested: {}".format(opts.sampler_method), " compare to ", mcsamplerPortfolio.known_pipelines)
+    # mcsamplerPortfolio is only bound if its import succeeded; reaching this line with a
+    # failed import used to raise NameError from the diagnostic itself.
+    print(" ILE requested: {}".format(opts.sampler_method), " compare to ",
+          sorted(mcsamplerPortfolio.known_pipelines) if mcsampler_Portfolio_ok else "<mcsamplerPortfolio unavailable>")
 
 #
 # Psi -- polarization angle


### PR DESCRIPTION
Driver-side half of making `--sampler-method portfolio` usable on `rift_O4c`. One file,
+26/-5, no new dependencies, no behaviour change for any sampler other than `portfolio`.

**Complementary to #168, not overlapping it.** #168 fixes the module side
(`mcsamplerPortfolio.py`): the unguarded entry-point plugin load, and the fair-draw backend.
This PR fixes the driver side (`integrate_likelihood_extrinsic_batchmode`), which #168 does not
touch. **Neither is sufficient alone** — see the measurements below. I have deliberately *not*
duplicated #168's plugin guard here, even though I had written an identical one, so the two
branches do not conflict; `3201b000` cherry-picks onto `4ddf41de` cleanly.

## Four defects, one kind

Every one of them answers a request the driver cannot honour with something other than an error.

**1. A dead raise, and a silent sampler substitution.**

```python
elif opts.sampler_method == "portfolio" and mcsampler_Portfolio_ok:
    if not(mcsampler_Portfolio_ok):
      raise Exception(" Portfolio integrator requested but not available")
```

The guard in the `elif` makes the very next statement unreachable, and routes an unavailable
portfolio past the whole chain to the terminal `else`, which prints `ILE: **original sampler**`
and proceeds with the plain `mcsampler.MCSampler` constructed before the chain. A run that asked
for the portfolio would have integrated with a different sampler and reported nothing unusual.
Dropping the flag from the test makes the existing raise reachable and correct.

**2. The `else` diagnostic itself raises.** It formats `mcsamplerPortfolio.known_pipelines`, but
that name is only bound when the import succeeded. So the branch that exists to explain a failed
import was the one that raised `NameError: name 'mcsamplerPortfolio' is not defined` — which is
what `--sampler-method portfolio` actually produced on any torch-free container.

**3.** The plugin-pipeline `elif` has the same unguarded dereference in its test. Gated on the
ok-flag.

**4. The documented spelling of `--sampler-portfolio` silently built the wrong portfolio.** The
option is `action='append'` while its help documents "comma-separated strings", and the member
loop had no `else`. So `--sampler-portfolio AV,GMM` arrived as the single member name `"AV,GMM"`,
matched no branch, and appended whatever `sampler` happened to hold — the plain `MCSampler` from
before the chain, or on later iterations the *previous member*. Measured on `4ddf41de` (#168 head),
rho_net 146.8:

```
 PORTFOLIO  ['AV,GMM']
PORTFOLIO: adding AV,GMM
  ===> FAILED ANALYSIS <====
'MCSampler' object has no attribute 'draw_simplified'
```

One member, wrong type, and an error that names neither the option nor the bad value. With this
PR the same invocation gives `PORTFOLIO: adding AV` / `PORTFOLIO: adding GMM`, and a bad name is
refused up front:

```
Exception:  --sampler-portfolio: unknown member 'BOGUS'.
            Known: AV, GMM, AC/adaptive_cartesian_gpu, ['AC', 'AV', 'GMM']
```

Both spellings (and a mix) are now accepted, so the help text stops lying rather than the
behaviour changing under anyone. `rift_O4d` carries the same defect 4; it is fixed here rather
than backported.

Note the committed demo harness has been splitting on commas *in shell* before invoking the
driver (`extrinsic_collapse_demo/run_demo.sh:58`) — a workaround for exactly this, which is why
only the `append` spelling had ever been exercised.

## Measurements

Same host (ldas-pcdev2, A100), same container, same injection, `run_snr140` (rho_net 146.8),
`--sampler-portfolio AV,GMM`:

| tree | result |
|---|---|
| `4ddf41de` (#168 head) | 1 member `"AV,GMM"`, dies `no attribute 'draw_simplified'` |
| `4ddf41de` + this PR | 2 members `AV`, `GMM`, portfolio constructs, reaches the integration loop |
| `4ddf41de` + this PR, member `BOGUS` | refused immediately, exit 1, message names the known members |

Every run logs its tree and commit; all three read `dirty=0`.

## What this does NOT fix

Reaching the integration loop is where this PR's scope ends, and the portfolio **still does not
complete on `rift_O4c`.** With #168 and this PR both applied it now fails one layer deeper, in
the AV member's prior evaluation:

```
  File ".../integrators/mcsamplerPortfolio.py", line 286, in draw
    joint_p_s_here, joint_p_prior_here, rv_here = member.draw_simplified(...)
  File ".../integrators/mcsamplerAdaptiveVolume.py", line 286, in prior_prod
    p_out *= self.prior_pdf[param](x[:,indx])
TypeError: Unsupported type <class 'numpy.ndarray'>
```

Same class of defect as #168's fair-draw fix — allocate on one backend, operate with the other.
I chased it two sites further, and **it is a chain, not a last mile**:

| # | site | |
|---|---|---|
| 1 | `mcsamplerAdaptiveVolume.prior_prod:286` | AV member |
| 2 | `mcsamplerEnsemble.calc_pdf:202` | GMM member |
| 3 | `mcsamplerPortfolio.integrate_log:471` | the portfolio itself |

all the same `TypeError`, each only visible once the previous one is fixed. Standalone `AV` and
`GMM` escape 1 and 2 for *different* reasons (the driver rebinds `mcsampler =
mcsamplerAdaptiveVolume` in the AV branch; `self.xpy` is numpy in standalone GMM), and a
portfolio breaks both assumptions at once. The O4c portfolio has evidently never run on a GPU host.

**`rift_O4d` carries fixes for all three, and backporting the first one verbatim regresses the
production path — so I am not proposing it here.** With the O4d `prior_prod` fix applied,
standalone AV at rho=51.4:

| tree | seeds 9201-9204 |
|---|---|
| `4a8703f3` | **4/4** converged, fairdraw 8, eff_samp 8.00-8.72 |
| `+ O4d prior_prod` | **0/4** — all four `TypeError: Unsupported type` |

because `mcsamplerGPU.uniform_samp_psi(x, xpy=...)` accepts `xpy` but its body is
`xpy.ones(len(x))/(cupy_pi)` with `cupy_pi = cupy.array(np.pi)` — the array honours the argument,
the constant does not. The O4c and O4d bodies of that helper are byte-identical, so the O4d fix
works upstream only in combination with the rest of O4d's backend hardening
(`identity_convert*` call sites: `mcsamplerEnsemble` 5 → 26, `mcsamplerPortfolio` 32 → 46,
`mcsamplerAdaptiveVolume` 38 → 52).

So: this PR makes the portfolio **selectable and honestly diagnosed**. It does not make it
**runnable** on `rift_O4c`, and that remainder is its own scoped job with its own inertness gate
on standalone AV *and* standalone GMM — not a follow-on commit. Full measurements and the
reproduce commands: `extrinsic_collapse_demo/run/O4C_PORTFOLIO_STATUS_2026-08-13.md`.
