### PR TITLE
ILE: label the exported time grid with the spacing the likelihood steps by (minimal, export path only)

### DIFF
--- a/MonteCarloMarginalizeCode/Code/bin/integrate_likelihood_extrinsic_batchmode
+++ b/MonteCarloMarginalizeCode/Code/bin/integrate_likelihood_extrinsic_batchmode
@@ -1330,7 +1330,12 @@ def resample_samples(my_samples,
 
   # if we are using GPU-based generation this is ok; if itis mcsampler, we will have a lot of 'object' casts to fix, arg
   
-  tvals = xpy_default.linspace(-t_ref_wind,t_ref_wind,int((t_ref_wind)*2/P.deltaT))  # choose an array at the target sampling rate. P is inherited globally
+  # Spacing must be deltaT, the step the likelihood takes: NoLoop reads only
+  # tvals[0] and len(tvals), then walks the Q_lm buffer one SAMPLE at a time from
+  # ifirst.  linspace(-W,W,npts) spans the closed interval, spacing 2W/(npts-1),
+  # so it mislabels those samples -- and t_out below becomes the exported 't_ref'.
+  # tvals[0] and len(tvals) are unchanged, so lnLt is bit-identical: labels only.
+  tvals = -t_ref_wind + float(P.deltaT)*xpy_default.arange(int((t_ref_wind)*2/P.deltaT))  # target sampling rate. P is inherited globally
   P.phi =  identity_convert_togpu(my_samples['right_ascension'])  # cast to float
   P.theta =   identity_convert_togpu(my_samples['declination'])
   P.tref = float(fiducial_epoch)
@@ -1360,13 +1365,13 @@ def resample_samples(my_samples,
   if opts.srate_resample_time_marginalization and opts.srate_resample_time_marginalization > fSample:
     # Resample the marginalization-time grid to EXACTLY the requested rate, so
     # the exported geocenter time is quantized at 1/srate_resample seconds.  We
-    # step by exactly 1/srate_resample rather than by an integer subdivision of
-    # the internal grid: that internal grid is a closed-interval linspace whose
-    # spacing is ~1/fSample but NOT exactly (here ~4086.7 Hz vs 4096), so an
-    # integer-factor upsample would land at ~n/deltaT_orig, tens of percent off
-    # the request.  For the usual power-of-two rates 1/srate is exactly
-    # representable in float64, so consecutive output times differ by exactly
-    # that step.
+    # step by exactly 1/srate_resample.  For the usual power-of-two rates 1/srate
+    # is exactly representable in float64, so consecutive output times differ by
+    # exactly that step.  (This comment used to justify the choice by the internal
+    # grid being a closed-interval linspace of spacing ~4086.7 Hz rather than 4096;
+    # that grid is now deltaT-spaced, so an integer-factor upsample would be exact
+    # too -- but more to the point its labels are now the times the likelihood
+    # actually evaluated.)
     dt_target = 1.0/opts.srate_resample_time_marginalization
     # floor(): stay within [tvals[0], tvals[-1]] so the spline never
     # extrapolates.  At most one step (<1/srate s, tens of us) is dropped at the

--- a/MonteCarloMarginalizeCode/Code/test/test_time_marginalization_grid_labels.py
+++ b/MonteCarloMarginalizeCode/Code/test/test_time_marginalization_grid_labels.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+The exported time grid must be labelled with the spacing the likelihood steps by.
+
+``bin/integrate_likelihood_extrinsic_batchmode`` built the export grid in
+``resample_samples()`` as
+
+    tvals = linspace(-t_ref_wind, t_ref_wind, int(t_ref_wind*2/P.deltaT))
+
+whose spacing is ``2W/(N-1)``.  ``DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop``
+does not step by that: it uses only ``tvals[0]`` (``tfirst = t_det + tvals[0]``) and
+then reads ``lnLt[k]`` from the precomputed Q_lm buffer at index ``ifirst + k``,
+i.e. at detector time ``tfirst + k*deltaT``.  Labelling those values with a
+closed-interval linspace stretches the exported time about the START of the window,
+
+    t_reported = t_true + (t_true - (event_time - W)) * delta,
+    delta      = (1 + f)/(N - 1),   with  2*W*srate = N + f
+
+which at the production settings (srate 4096, W = 75 ms) is +171 us at the window
+centre and +0.23% on the width of any exported time posterior.
+"""
+
+import os
+import re
+
+import numpy as np
+import pytest
+
+SRATE = 4096.0
+WINDOW_HALF = 75e-3          # --data-integration-window-half default
+
+ILE_SCRIPT = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "bin",
+    "integrate_likelihood_extrinsic_batchmode",
+)
+
+
+def npts(srate=SRATE, window_half=WINDOW_HALF):
+    return int(window_half*2/(1.0/srate))
+
+
+def tvals_fixed(srate=SRATE, window_half=WINDOW_HALF):
+    """The corrected grid: same first sample and same length, spacing tied to deltaT."""
+    return -window_half + (1.0/srate)*np.arange(npts(srate, window_half))
+
+
+def tvals_legacy(srate=SRATE, window_half=WINDOW_HALF):
+    """The construction that shipped through O4c."""
+    return np.linspace(-window_half, window_half, npts(srate, window_half))
+
+
+def label_bias(t, srate=SRATE, window_half=WINDOW_HALF):
+    """Predicted legacy label error at a time t relative to the event time."""
+    x = 2*window_half*srate
+    n = int(x)
+    return (t + window_half)*(1 + (x - n))/(n - 1)
+
+
+def test_corrected_grid_is_spaced_by_deltaT():
+    assert np.allclose(np.diff(tvals_fixed()), 1.0/SRATE, rtol=0, atol=1e-15)
+
+
+def test_the_fix_changes_only_the_labels():
+    """
+    The likelihood consumes tvals[0] and len(tvals) and nothing else, so a fix that
+    preserves both cannot move lnL, lnZ, or which data samples are integrated.
+    """
+    leg, fix = tvals_legacy(), tvals_fixed()
+    assert len(leg) == len(fix)
+    assert leg[0] == fix[0] == -WINDOW_HALF
+
+
+@pytest.mark.parametrize("t_true", [-40e-3, -20e-3, 0.0, 20e-3, 40e-3])
+def test_legacy_bias_matches_the_closed_form(t_true):
+    """
+    Index the two grids identically -- which is what the likelihood does, since it
+    walks the Q buffer one sample at a time from tvals[0] -- and the difference in
+    the labels IS the bias.
+    """
+    k = int(round((t_true + WINDOW_HALF)*SRATE))
+    fix = tvals_fixed()
+    err = tvals_legacy()[k] - fix[k]
+    # evaluate the closed form AT THE GRID NODE, not at the requested time: k is
+    # rounded, so the node can sit up to half a sample away from t_true.
+    assert err == pytest.approx(label_bias(fix[k]), abs=1e-9)
+
+
+@pytest.mark.parametrize("srate,expect_us", [(4096, 171.3), (8192, 110.0), (16384, 48.9)])
+def test_bias_at_the_window_centre(srate, expect_us):
+    """
+    delta is (1+f)/(N-1), not 1/srate: it depends on the fractional part of
+    2*W*srate, so the progression is not a clean factor of two.
+    """
+    assert label_bias(0.0, srate=srate)*1e6 == pytest.approx(expect_us, abs=0.5)
+
+
+def test_width_is_stretched_by_delta():
+    """A posterior spanning [a, b] was reported 0.2284% wider at srate 4096."""
+    ka = int(round((-20e-3 + WINDOW_HALF)*SRATE))
+    kb = int(round((+20e-3 + WINDOW_HALF)*SRATE))
+    leg, fix = tvals_legacy(), tvals_fixed()
+    stretch = (leg[kb] - leg[ka])/(fix[kb] - fix[ka]) - 1
+    x = 2*WINDOW_HALF*SRATE
+    n = int(x)
+    assert stretch == pytest.approx((1 + (x - n))/(n - 1), rel=1e-6)
+
+
+def _export_grid_expression():
+    """The right-hand side of the export-path grid, as the driver spells it today.
+
+    Anchored on ``P.phi = identity_convert_togpu(...)``, the line that immediately
+    follows it in resample_samples(): that is the grid whose labels become the
+    exported 't_ref'.
+    """
+    with open(ILE_SCRIPT) as f:
+        src = f.read()
+    m = re.search(r"tvals\s*=\s*([^\n]*)\n\s*P\.phi\s*=\s*identity_convert_togpu", src)
+    assert m, "could not find the export-path time grid in %s" % ILE_SCRIPT
+    return m.group(1).split("#")[0].strip()
+
+
+def test_export_path_grid_is_not_a_closed_interval_linspace():
+    """
+    Drift guard on the one line this patch changes.  A closed-interval linspace over
+    the window silently reintroduces the +171 us bias in the exported time.
+    """
+    expr = _export_grid_expression()
+    assert "linspace" not in expr, \
+        "export time grid is a closed-interval linspace again: %r" % expr
+    assert "arange" in expr and "deltaT" in expr, \
+        "export time grid no longer steps by deltaT: %r" % expr
+    assert "-t_ref_wind" in expr, \
+        "export time grid no longer starts at -t_ref_wind: %r" % expr
+
+
+def test_source_grid_reproduces_the_reference_grid():
+    """Evaluate the shipped expression itself, so this test cannot drift from it."""
+    expr = _export_grid_expression()
+    for srate in (1024, 2048, 4096, 8192, 16384):
+        ns = {"t_ref_wind": WINDOW_HALF, "xpy_default": np,
+              "P": type("P", (), {"deltaT": 1.0/srate})()}
+        got = eval(expr, ns)
+        # nothing is injected but the window and deltaT, so the shipped expression
+        # must supply its own npts: a wrong point count fails here, not silently.
+        assert len(got) == npts(srate), (
+            "srate %d: shipped grid has %d points, expected int(2*W/deltaT) = %d"
+            % (srate, len(got), npts(srate)))
+        np.testing.assert_allclose(got, tvals_fixed(srate), rtol=0, atol=1e-15)


### PR DESCRIPTION
**DRAFT.** Minimal, export-path-only fix for a time-labelling defect that is present in
every GWTC-6 production run. Opened as a draft against `oshaughn:rift_O4c` because this is
the branch `Reviewed-RIFT-20260807.sif` (tag 0.0.17.13) is built from and it needs a
minimal path forward. No review requested.

## The defect

`resample_samples()` builds the time-marginalization grid as

```python
tvals = linspace(-t_ref_wind, t_ref_wind, int(t_ref_wind*2/P.deltaT))
```

whose spacing is `2W/(N-1)`. The likelihood does not step by that.
`DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop` uses only `tvals[0]` — it sets
`tfirst = t_det + tvals[0]` — and then reads `lnLt[k]` from the precomputed Q_lm buffer at
index `ifirst + k`, i.e. at detector time `tfirst + k*deltaT`. Labelling those values with
a closed-interval linspace stretches the reported time about the **start** of the window:

```
t_reported = t_true + (t_true - (event_time - W)) * delta
delta      = (1 + f)/(N - 1),   where  2*W*srate = N + f
```

At the production settings (`--srate 4096`, `--data-integration-window-half 0.075`):
`N = 614`, `f = 0.4`, `delta = 0.0022838`, so

* the exported geocentre time is **+171 µs late at the window centre** (+80 µs at −40 ms
  rising to +263 µs at +40 ms), and
* any exported time posterior is **0.23 % too wide**.

`delta` is not `1/srate` — it depends on the fractional part of `2*W*srate`:

| `--srate` | N | delta | bias at window centre |
|---:|---:|---:|---:|
| 4096  | 614  | 0.0022838  | **+171.3 µs** |
| 8192  | 1228 | 0.0014670  | +110.0 µs |
| 16384 | 2457 | 0.00065147 | +48.9 µs |

Neither existing option works around it. `--interpolate-time` does not (the cubic stencil
still steps exactly one sample), and `--srate-resample-time-marginalization` does not (the
dense export grid is built as `tvals[0] + arange(n)/srate_resample` and inherits the
mislabelling).

The likely origin is someone making the integer grid-size rounding come out right:
`int(2W/deltaT)` and `tvals[0]` are both already correct, only the *spacing of the labels*
is wrong.

## The fix

One line: tie the label spacing to `deltaT`, the step the likelihood actually takes.

```python
tvals = -t_ref_wind + float(P.deltaT)*xpy_default.arange(int((t_ref_wind)*2/P.deltaT))
```

`tvals[0]` and `len(tvals)` are unchanged, so the likelihood reads **exactly the same**
Q_lm samples. This relabels the times; it does not move the likelihood.

Deliberately *not* the `rift_O4d` convention. `rift_O4d` (junior PR #162, issue #146) now
uses a centred grid, `(arange(npts) - npts//2)*deltaT`, so that `t = 0` sits on the grid
and the JAX driver agrees sample-for-sample. That shifts `tvals[0]` by 0.2 samples, which
can round `ifirst` to a different integer and therefore change which data samples are
integrated. Keeping `tvals[0] = -t_ref_wind` here is what makes this patch provably
numerically inert, which is the right trade for the release branch.

## Scope: why only this one site

There are seven grid sites in this file. This is the only one whose `tvals` **values leave
the process as data** (they become `t_out`, hence the exported `t_ref`). Checked on the
O4c file, not assumed — the branch lines have diverged:

* **4 sites** (1583, 1632, 1738, 1782) feed `DiscreteFactoredLogLikelihoodViaArrayVector`
  / `...NoLoop`, which consume only `tvals[0]` and `len(tvals)` and integrate with
  `dx=deltaT`. Relabelling them changes nothing at all, so a minimal patch leaves them.
* **2 sites** (1553, 1835) feed `FactoredLogLikelihoodTimeMarginalized`, which integrates
  with `dx=tvals[1]-tvals[0]` (`factored_likelihood.py:694`). Fixing those *would* shift
  `lnL` by a constant `-log(1+delta) = -0.00228` nats on the non-vectorized and ROM paths.
  Correct, but not numerically inert, so out of scope here.

## Verification

**Against the shipped likelihood on this branch** (synthetic Q_lm carrying a feature at a
known detector arrival time, `<h|h>` cross terms zeroed so `lnL(t)` tracks the feature):

```
Q1  lnLt bitwise identical under the two grids : True   (max |dlnLt| = 0.000e+00)
Q2  time-marginalized lnL                      : -1.9389090783052292 under both, identical
Q5  npts at srate 1024/2048/4096/8192/16384    : unchanged (153/307/614/1228/2457)
    tvals[0] at every rate                     : unchanged
```

Recovered peak position of the injected feature:

```
t_true[ms]   legacy err[us]    fixed err[us]   predicted[us]
     -40.0            97.12            17.15           79.93
     -20.0           142.72            17.07          125.61
      -5.0           177.17            17.26          159.87
       0.0           188.37            17.04          171.29
       5.0           200.25            17.50          182.71
      20.0           234.05            17.05          216.97
      40.0           279.76            17.08          262.64
```

`legacy − fixed` matches the closed form above to **better than 0.05 µs** at every offset.
The residual +17 µs that survives is *constant* — it is the separate nearest-sample
detector-time snap for that sky position, not this defect.

**`--srate-resample-time-marginalization`** still lands on exactly `1/srate_resample`:

```
srate_resample   n_dense (legacy -> fixed)   step exactly 1/srate_resample   stays <= tvals[-1]
       8192            1229 -> 1227                     yes                        yes
      16384            2458 -> 2453                     yes                        yes
      32768            4916 -> 4905                     yes                        yes
```

The dense grid loses a few points at the far edge because `tvals[-1]` moves from `+W` (a
label the likelihood never actually evaluated) to the last real sample. No coverage is
lost: the likelihood always evaluated `npts` samples stepping `deltaT` from `-W`, and the
old code merely mislabelled the last of them as `+W`.

**On real data** (recorded separately, not rerun here): re-running the extrinsic stage of
GWTC-6 **a placeholder event** over identical blocks of the final intrinsic grid with this correction
moves the exported posterior by **−146.4 ± 22.6 µs against a −149.4 µs prediction fixed
before the run**, with a null replicate (same arguments, different RNG) at +14.4 ± 23.8 µs.

## How much does it matter in practice

JS divergence attributable to this defect alone, per event, over the 21 GWTC-6 events with
a bilby SEOBNRv5PHM counterpart (the bias is a deterministic map, so it is evaluated by
applying the inverse map to the production samples — no rerun needed):

```
median JS from the bug alone : 6.73e-04 bits
max    JS from the bug alone : 2.39e-02 bits  (a placeholder event)
median JS RIFT vs bilby      : 5.73e-03 bits
bug / total, median ratio    : 17.4 %
```

So it is **negligible for poorly-localised events** — median 6.7e-4 bits, below the
~2e-3 bit scale at which these comparisons are normally called indistinguishable, on the
broad (≈40 ms wide) events — and **dominant for sharply-localised ones**: 2.4e-2 bits on
a placeholder event (90 % width 1.65 ms), which is *larger than the entire current RIFT-vs-bilby JS
for that event* (1.2e-2 bits), and 1.1e-2 bits on a placeholder event.

## Tests

`MonteCarloMarginalizeCode/Code/test/test_time_marginalization_grid_labels.py` (13 tests,
no GPU, no data): the corrected grid's spacing, that `tvals[0]` and `len(tvals)` are
preserved, the closed-form bias at five offsets, the srate ladder, the width stretch, and
a drift guard that reads the shipped source line, evaluates it at five sample rates, and
fails if the export grid becomes a closed-interval linspace again.

Verified to fail for the right reason. Against the unpatched tree the two source-reading
guards fail and the other eleven pass. Mutation battery, with the unmutated control run
through the same scoring path:

```
control (unmutated)          : 13 passed
npts halved                  :  1 failed
npts + 1                     :  1 failed
origin sign flipped          :  2 failed
spacing doubled              :  1 failed
the original bug restored    :  2 failed
```

(An earlier revision of this patch introduced `_npts_t` on its own line; review caught that
the guard then never evaluated it and the "npts halved" mutant survived. `npts` is now
inlined into the guarded expression.)

Run with:

```
PYTHONPATH=MonteCarloMarginalizeCode/Code pytest -q \
  MonteCarloMarginalizeCode/Code/test/test_time_marginalization_grid_labels.py
```

## Not addressed here

A second, independent defect in the same machinery — the nearest-sample detector-time snap
broadens the time posterior where the inter-detector delay is sharp (the constant +17 µs
above, and a +12.5 % width excess on a placeholder event). `rift_O4d` has `--interpolate-time` for it;
`rift_O4c` does not. Out of scope for a minimal release-branch patch.
