### PR TITLE
ILE: band-limited time-marginalization quadrature (opt-in; defaults unchanged)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,6 +47,15 @@ import_check:
   script:
     - python .travis/test-all-mod.py
 
+unit_tests:
+  stage: system tests
+  script:
+    # Nothing else in this file runs pytest, so a test file that is not NAMED
+    # here never runs at all.  The collect-only line is a guard: a collection
+    # error yields zero tests, and "0 tests" must not read as a pass.
+    - python -m pytest --collect-only -q MonteCarloMarginalizeCode/Code/test/test_time_marginalization_quadrature.py MonteCarloMarginalizeCode/Code/test/test_time_marginalization_wiring.py MonteCarloMarginalizeCode/Code/test/test_time_marginalization_cli.py | grep -E '^[0-9]+ tests? collected'
+    - python -m pytest -q MonteCarloMarginalizeCode/Code/test/test_time_marginalization_quadrature.py MonteCarloMarginalizeCode/Code/test/test_time_marginalization_wiring.py MonteCarloMarginalizeCode/Code/test/test_time_marginalization_cli.py
+
 test_run:
   stage: system tests
   script:

--- a/MonteCarloMarginalizeCode/Code/RIFT/likelihood/factored_likelihood.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/likelihood/factored_likelihood.py
@@ -63,6 +63,7 @@ from itertools import product, combinations
 import math
 
 from .vectorized_lal_tools import ComputeDetAMResponse,TimeDelayFromEarthCenter
+from . import time_marginalization_quadrature as time_quad
 
 import os
 if 'PROFILE' not in os.environ:
@@ -1805,7 +1806,7 @@ def _factored_lnL_helper(kappa_sq, rho_sq):
     return kappa_sq - 0.5 * rho_sq
 
 
-def  DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop(tvals, P_vec, lookupNKDict, rholmsArrayDict, ctUArrayDict,ctVArrayDict,epochDict,Lmax=2,array_output=False,xpy=np, loglikelihood=_factored_lnL_helper,return_lnLt=False,phase_marginalization=False):
+def  DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop(tvals, P_vec, lookupNKDict, rholmsArrayDict, ctUArrayDict,ctVArrayDict,epochDict,Lmax=2,array_output=False,xpy=np, loglikelihood=_factored_lnL_helper,return_lnLt=False,phase_marginalization=False,time_quadrature='simpson'):
     """
     DiscreteFactoredLogLikelihoodViaArray uses the array-ized data structures to compute the log likelihood,
     either as an array vs time *or* marginalized in time. 
@@ -1813,8 +1814,38 @@ def  DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop(tvals, P_vec, lookupNKDic
     The timeseries quantities are computed via discrete shifts of an existing grid
     Note 'P' must have the *sampling rate* set to correctly interpret the event time.
      Note arguments passed are NOW ARRAYS, in contrast to similar function which does not have 'Vector' postfix
+
+    time_quadrature : {'simpson', 'bandlimited'}
+        How the time-marginalization integral is evaluated.
+
+        'simpson' (DEFAULT, and the historical behavior) applies Simpson's rule
+        at the fixed spacing dx=deltaT.  That spacing is tied to the data
+        sample rate, while the integrand exp(lnL(t)) is a peak of width
+        sigma_t = 1/(2 pi rho sigma_f), which SHRINKS like 1/rho -- so this
+        path under-resolves its own integrand, and worse the louder the event.
+        Simpson is additionally the wrong rule once under-resolved: it is
+        (4 T_h - T_2h)/3, so it carries an alias of period 2h and the answer
+        depends on where the peak happens to fall between samples.
+
+        'bandlimited' recovers the continuous integrand from the samples the
+        code has ALREADY computed -- kappa(t) is band-limited and rho_sq is
+        time-independent on this path, so one zero-padded FFT per row is exact
+        -- re-applies THIS loglikelihood callback on the dense grid, and
+        integrates with the trapezoid rule, whose error on a Gaussian peak
+        falls as 2 exp(-2 pi^2 (sigma_t/h)^2).  The upsampling factor is
+        DERIVED from the measured peak width and then re-verified on the dense
+        grid; there is deliberately no accuracy-versus-cost knob for a caller
+        to set too small.  No extra likelihood evaluations, no extra
+        precompute, and the integration domain is unchanged.
+
+        This argument defaults to 'simpson' and the batch-mode CLI's
+        --time-marginalization-quadrature defaults to 'simpson', so omitting
+        either reproduces the historical numbers exactly.  Details and the
+        error model: RIFT/likelihood/time_marginalization_quadrature.py.
     """
     global distMpcRef
+
+    time_quad.validate_time_quadrature(time_quadrature)
 
     detectors = rholmsArrayDict.keys()
     npts = len(tvals)
@@ -2033,6 +2064,20 @@ def  DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop(tvals, P_vec, lookupNKDic
     lnLmax  = xpy.max(lnL_t)
     if return_lnLt:
       return lnL_t  #- lnLmax    # we want the verbatim lnL_t values, no shift
+
+    if time_quadrature == 'bandlimited':
+        # Hand over the coarse lnL_t just built (so the callback is not
+        # re-evaluated) and deltaT -- the spacing the gather actually steps by.
+        # NOT tvals[1]-tvals[0]: on this line the window grid is a
+        # closed-interval linspace whose spacing is deltaT*npts/(npts-1).
+        # simps and lnLmax are handed over so that wrap-exposed rows fall back
+        # to THIS path's Simpson value bit-for-bit (the GPU build uses
+        # optimized_gpu_tools.simps, which the quadrature module must not import).
+        return time_quad.time_marginalize_bandlimited(
+            kappa_sq, rho_sq, deltaT, loglikelihood,
+            phase_marginalization=phase_marginalization, lnL_t=lnL_t,
+            simps=simps, lnLmax=lnLmax, xpy=xpy)
+
     L_t = xpy.exp(lnL_t - lnLmax, out=lnL_t)
 
     L = simps(L_t, dx=deltaT, axis=-1)

--- a/MonteCarloMarginalizeCode/Code/RIFT/likelihood/time_marginalization_quadrature.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/likelihood/time_marginalization_quadrature.py
@@ -1,0 +1,619 @@
+"""Band-limited quadrature for the ILE time marginalization.
+
+WHAT IS WRONG WITH THE HISTORICAL PATH
+--------------------------------------
+``DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop`` integrates
+``exp(lnL(t))`` over the marginalization window with Simpson's rule at a FIXED
+spacing ``dx = deltaT = 1/srate``.  The integrand's width is not fixed: after
+the angle/phase reductions ``exp(lnL(t))`` is a near-Gaussian peak of width
+
+    sigma_t = 1 / (2 pi rho sigma_f)
+
+with ``sigma_f`` the noise-weighted template frequency spread.  ``sigma_t``
+shrinks like 1/rho, so a grid tied to the data sample rate under-resolves its
+own integrand, and does so WORSE the louder the event.
+
+Simpson is the wrong rule in that regime.  ``simpson = (4 T_h - T_2h)/3``
+carries the coarser trapezoid ``T_2h`` with a minus sign, so it inherits an
+alias with period ``2h`` -- which is why the historical value depends on where
+the peak happens to fall between samples.  Trapezoid, by contrast, is
+spectrally accurate on a Gaussian: by Poisson summation its relative error is
+
+    ~ 2 exp(-2 pi^2 (sigma_t/h)^2)
+
+so it needs only ``h <~ sigma_t`` and then converges at a rate no polynomial
+rule can match.  That bound is what ``UPSAMPLE_SAFETY`` is derived from; it is
+not a tuning constant.
+
+THE FIX
+-------
+``kappa(t)`` (the data term) is band-limited -- it is built from the rholm
+cross-correlation timeseries -- and on this path ``rho_sq`` (the template
+self-term) is time-independent.  By the sampling theorem the samples the code
+ALREADY computed determine the continuous ``kappa(t)`` exactly, so one
+zero-padded FFT per row recovers it at any spacing: no extra likelihood
+evaluations, no extra precompute, no new physics.  We then apply the SAME
+``loglikelihood`` callback on the dense grid and integrate with the trapezoid
+rule.
+
+Because the callback is applied after upsampling, this is correct for every
+caller -- the plain helper, phase marginalization (``|kappa|``), and the
+distance-marginalization table lookup alike.  For the same reason the
+resolution requirement is derived from ``lnL(t)`` itself and never from
+``kappa``: ``lnL`` is affine in ``kappa`` only for the default helper.
+
+WHAT THIS MODULE DELIBERATELY DOES NOT DO
+-----------------------------------------
+* It does not change the integration DOMAIN.  The dense grid spans exactly
+  ``[t_0, t_{npts-1}]``, the closed interval Simpson used; the only dense
+  samples discarded are the ``factor-1`` that lie past the last coarse sample,
+  which are precisely the ones sitting across the FFT's periodic wrap.  An
+  edge taper would shrink the domain instead, which is invisible for a sharp
+  interior peak but is a real error for a flat, low-amplitude integrand -- the
+  regime where the historical path was already fine.
+* It does not re-centre the window.  Rows whose peak sits at the very first or
+  last sample are COUNTED and reported (``last_report()['n_edge_peak_rows']``),
+  not repaired: a mis-centred window is a separate defect and is not smuggled
+  in here.  (This is distinct from ``EDGE_GUARD_FRACTION`` below, which does
+  act -- by handing those rows back the historical value untouched.)
+* It exposes no accuracy-versus-cost knob.  The upsampling factor is derived
+  from the measured peak width and then re-verified on the dense grid; it
+  cannot be set too small by a caller.
+
+On the DENSE grid the choice of trapezoid over Simpson buys COST, not accuracy:
+at ``h <= sigma_t/2`` Simpson would also be far below any error that matters.
+Trapezoid reaches the same bound at half the resolution, which is a factor of
+two off the dominant cost.  It is on the COARSE grid that Simpson is actively
+the wrong rule.
+
+Backend notes (``xpy`` is ``numpy`` or ``cupy``; this module imports nothing
+from RIFT, so the same file serves the rift_O4c and rift_O4d lines):
+
+* **Untested on GPU.**  Every array call used here exists in cupy and all of
+  them already appear in this repo's cupy paths -- but it has not been run on a
+  GPU and should not be described as though it had.
+* **It synchronises.**  The refinement decision needs host-side scalars, so
+  there are a handful of device-to-host transfers per block and two per memory
+  chunk.  Free on CPU; on GPU a large batch could spend real time there.  If
+  this is ever enabled on GPU, profile it rather than assuming the measured CPU
+  cost ratios carry over.
+* ``rho_sq`` reaches the callback as a **read-only broadcast view** on the dense
+  path, where the historical path passed a writable array.  Every shipped
+  callback allocates rather than writing in place (the distance-marginalization
+  one was checked end-to-end), but a callback that wrote to ``rho_sq`` would
+  work historically and raise here.
+"""
+
+import numpy as np
+
+__all__ = [
+    "TIME_QUADRATURE_CHOICES", "UPSAMPLE_SAFETY", "UPSAMPLE_FACTOR_MAX",
+    "EDGE_GUARD_FRACTION", "SUPPORT_NATS", "validate_time_quadrature", "bandlimited_upsample", "peak_width_from_lnL",
+    "required_upsample_factor", "time_marginalize_bandlimited", "last_report",
+]
+
+#: Accepted values of the ``time_quadrature`` argument.  ``'simpson'`` is the
+#: historical behavior and remains the default everywhere.
+TIME_QUADRATURE_CHOICES = ("simpson", "bandlimited")
+
+#: Samples demanded per Gaussian sigma: ``h <= sigma_t / UPSAMPLE_SAFETY``.
+#: With the Poisson-summation bound ``2 exp(-2 pi^2 (sigma/h)^2)`` above, 2.0
+#: leaves a residual quadrature error of ~2e-34 -- far below every other error
+#: in the calculation, which is the point: this constant should never be the
+#: reason a result is wrong, and it is not exposed to callers.
+UPSAMPLE_SAFETY = 2.0
+
+#: Rows whose peak falls within this fraction of the window at either end are
+#: handed back the HISTORICAL Simpson value, bit for bit, instead of the
+#: band-limited one.  The FFT interpolant is periodic, so a peak near the window
+#: edge sits next to the wrap and the reconstruction is not merely inaccurate
+#: there but wrong in the dangerous direction: a spuriously HIGH lnL biases the
+#: evidence up and importance-weights that sample into dominance.  Measured with
+#: the guard disabled, against an analytic non-periodic integrand: +0.0006 nats
+#: at 32 bins from the edge (the guard boundary here), +0.017 at 16, +0.16 at 8,
+#: +2.2 at 0 -- and the companion rift_O4d measurement, with a sharper peak,
+#: reached +88.8.  The magnitude depends on the peak; the sign does not.
+#: The deviation cannot be estimated from the window's own samples (the periodic
+#: band-limited interpolant is uniquely determined by them, so bounding the
+#: departure needs information from outside), so it has to be bounded a priori.
+#: The guard makes the wrap failure mode UNREACHABLE: no row can be handed a
+#: value contaminated by the periodic wrap, because a row whose peak is near the
+#: wrap is returned untouched.  Combined with the refinement predicate below,
+#: the property is: a row's value differs from the historical one IF AND ONLY IF
+#: its integrand was under-resolved.  That is NOT the same as promising every
+#: row is at least as accurate as Simpson -- the refined path carries its own
+#: ~1e-4 nat residual at the sharpest amplitudes measured, and a row where
+#: Simpson's error happens to cross zero could be marginally better under the
+#: old rule.  State the failure mode, not an accuracy ordering.
+#:
+#: The band is a FRACTION of the window, so it interacts with
+#: --data-integration-window-half.  Measured, 2000 random-sky rows at rho=10:
+#:
+#:     iwh (s)   0.075   0.050   0.030   0.020   0.010
+#:     exposed    0.0%    0.0%   33.5%   23.4%   41.4%
+#:
+#: At the 0.075 s default no row is ever claimed.  Narrow the window and a large
+#: share of rows falls back to Simpson -- still correct, but the option stops
+#: doing anything for them.  last_report()['n_wrap_exposed_rows'] and
+#: ['n_refined_rows'] are how you see that; check them before concluding an
+#: enabled run actually used the new path.
+#:
+#: The real fix is a wider GATHER, so the wrap falls outside the integration
+#: domain; that touches the GPU kernel and its buffer-margin assumptions and is
+#: deliberately not done here.
+EDGE_GUARD_FRACTION = 0.125
+
+#: Only bins within this many nats of a row's maximum can affect the integral
+#: (exp(-100) ~ 4e-44, so even summed over every dense sample they are far below
+#: float64 resolution).  The curvature scan is restricted to them.  Without
+#: that restriction the scan is unbounded below: numerical noise in a far tail,
+#: a distance-marginalization table edge, or a row where kappa is essentially
+#: zero can present an arbitrarily narrow "feature", which would inflate the
+#: derived factor for every row in its group and can reach the raising ceiling
+#: on a row that contributes nothing.
+SUPPORT_NATS = 100.0
+
+#: Refusal threshold.  Reaching it means the integrand is orders of magnitude
+#: sharper than the grid can describe, which is a modelling problem (or a bug),
+#: not something to silently truncate to a "best effort" answer.
+UPSAMPLE_FACTOR_MAX = 4096
+
+#: Working-set budget for the dense arrays, in bytes.  Internal only: it splits
+#: the extrinsic axis into chunks and cannot change the answer.
+_DENSE_CHUNK_BYTES = 128 * 1024 * 1024
+
+_LAST_REPORT = {}
+
+
+def last_report():
+    """Diagnostics from the most recent :func:`time_marginalize_bandlimited`.
+
+    Keys:
+
+    ``factor``
+        Largest upsampling actually used in the batch.
+    ``factor_initial``
+        Largest factor derived from the COARSE grid, before the dense
+        re-verification.  ``factor > factor_initial`` means the re-verification
+        fired, i.e. the coarse-grid width estimate was optimistic.
+    ``factor_histogram``
+        ``{factor: n_rows}``.  The factor is derived PER ROW, so a handful of
+        sharp rows do not impose their resolution on the whole batch; this is
+        where the cost went.
+    ``sigma_t_min``, ``sigma_t_min_dense``
+        Sharpest integrand width found (s), on the coarse and dense grids.
+    ``npts``, ``npts_dense``, ``n_rows``, ``n_chunks``
+        Shapes and the internal memory chunking.
+    ``n_wrap_exposed_rows``
+        Rows handed back the historical Simpson value because their peak fell
+        within ``EDGE_GUARD_FRACTION`` of a window edge.
+    ``n_edge_peak_rows``
+        Rows whose peak is at the very first or last sample -- a mis-centred
+        window, which is a SEPARATE defect this change does not address.
+        Reported so it is visible, not repaired.
+    ``n_nonfinite_rows``
+        Rows whose lnL is not finite anywhere (e.g. entirely outside the
+        distance-marginalization table).  Their curvature is UNMEASURABLE, not
+        zero, so they derive factor 1 -- and would otherwise appear in a
+        histogram as cheap rows and in a timing table as a speedup, when in fact
+        nothing was refined.  Counted unconditionally.
+    ``n_flat_rows``
+        Rows with finite lnL and no resolvable curvature -- no signal to refine
+        (e.g. an extrinsic sample in an antenna null, where kappa is numerically
+        zero and lnL is constant).
+    ``n_resolved_rows``
+        Rows with a peak the grid ALREADY resolves, so factor 1 and nothing to
+        do.  This is the cheap-and-correct population.
+
+    These five -- refined, resolved, wrap-exposed, flat, nonfinite -- PARTITION
+    the batch: every row is in exactly one, and only ``n_refined_rows`` changed
+    value relative to the historical path.
+
+    Returns a copy.
+    """
+    return dict(_LAST_REPORT)
+
+
+def validate_time_quadrature(time_quadrature):
+    """Return `time_quadrature`, or raise ValueError naming the valid choices."""
+    if time_quadrature not in TIME_QUADRATURE_CHOICES:
+        raise ValueError(
+            "time_quadrature must be one of {}, got {!r}".format(
+                TIME_QUADRATURE_CHOICES, time_quadrature))
+    return time_quadrature
+
+
+def bandlimited_upsample(x, factor, xpy=np):
+    """Zero-padded-FFT (band-limited) upsample of the LAST axis by `factor`.
+
+    ``x`` is treated as `factor` times oversampled samples of a periodic
+    band-limited function; the returned array has ``n*factor`` samples of that
+    same function, and reproduces the input exactly at indices ``j*factor``.
+    Handles even ``n`` (the Nyquist bin is split half to each of +/-f_Nyq, the
+    only choice that keeps a real input real) and odd ``n`` (no Nyquist bin).
+    """
+    factor = int(factor)
+    if factor < 1:
+        raise ValueError("factor must be >= 1, got {}".format(factor))
+    if factor == 1:
+        return x
+    n = x.shape[-1]
+    n_dense = n * factor
+    X = xpy.fft.fft(x, axis=-1)
+    Y = xpy.zeros(x.shape[:-1] + (n_dense,), dtype=complex)
+    n_pos = (n + 1) // 2          # bins 0 .. n_pos-1 are the non-negative freqs
+    n_neg = n - n_pos             # bins n_pos .. n-1 are the negative freqs
+    Y[..., :n_pos] = X[..., :n_pos]
+    if n_neg:
+        Y[..., n_dense - n_neg:] = X[..., n_pos:]
+    if n % 2 == 0:
+        # X[n//2] is the Nyquist bin: it is a cosine of ambiguous sign, and the
+        # band-limited interpolant is the one that splits it symmetrically.
+        half = 0.5 * X[..., n // 2]
+        Y[..., n // 2] = half
+        Y[..., n_dense - n // 2] = half
+    return xpy.fft.ifft(Y, axis=-1) * factor
+
+
+def peak_width_from_lnL(lnL_t, dx, xpy=np):
+    """Width of the SHARPEST feature in each row of ``exp(lnL_t)``, and the argmax.
+
+    Uses the three-point second difference of ``lnL_t`` -- NOT of ``kappa`` and
+    NOT of ``exp(lnL_t)`` -- taken at EVERY interior bin, and reports the
+    largest curvature found::
+
+        d2[j]   = (lnL[j-1] - 2 lnL[j] + lnL[j+1]) / dx**2
+        sigma_t = 1 / sqrt(max_j(-d2[j]))
+
+    Three properties, and all three are load-bearing.
+
+    1. For a Gaussian ``exp(lnL)``, ``lnL`` is exactly quadratic, and the
+       second difference of a quadratic is its second derivative at ANY spacing
+       and ANY offset between the peak and the grid.  So a peak the grid cannot
+       resolve still reports its own width honestly, which is what lets the
+       upsampling factor be derived rather than guessed.
+
+    2. It reads ``lnL_t``, so it is agnostic to which ``loglikelihood``
+       callback produced it.  A rule built on ``kappa``'s curvature would be
+       correct only for the affine default helper and would silently
+       under-resolve the phase- and distance-marginalized runs, which are the
+       production configurations.
+
+    3. It scans the WHOLE row rather than only the neighbourhood of the argmax.
+       The quantity the quadrature needs is the width of the SHARPEST feature
+       present, not the width of the tallest one, and when the peak is much
+       narrower than the grid no sample need land near it, so in principle the
+       coarse argmax can sit on an unrelated, shallower feature.  Being honest
+       about what this buys: an A/B of the two rules against the analytic
+       reference (band-limited pulses AND adversarial combs, three amplitudes,
+       25 seeds, five sub-sample offsets) found NO case where they gave
+       different answers -- the worst argmax-rule error was 1.3e-7 nats, the
+       same as the sharpest-feature rule's, and on physical kappa(t) the
+       sampled argmax does track the true peak (measured widths were stable to
+       <3% across a full grid-phase scan on a real injection).  This is
+       therefore a conservative variant, not a bug fix: it can only ever return
+       a smaller sigma, hence a finer grid, at the cost of one array pass.
+
+    Rows with no concave interior bin (flat or convex: nothing to resolve)
+    return ``inf``, i.e. "no upsampling required".
+
+    Returns ``(sigma_t, argmax)``, both shape ``lnL_t.shape[:-1]``.  The argmax
+    is returned for the edge-row diagnostic, not for the width.
+    """
+    n = lnL_t.shape[-1]
+    if n < 3:
+        raise ValueError("need at least 3 time samples, got {}".format(n))
+    d2 = (lnL_t[..., :-2] - 2.0 * lnL_t[..., 1:-1] + lnL_t[..., 2:]) / (dx * dx)
+
+    # Restrict to bins that can actually affect the integral, and drop
+    # non-finite curvature.  Both matter in production: the
+    # distance-marginalization callback returns -inf outside its table, and
+    # (-inf) - 2(-inf) + (-inf) is NaN, which would poison a plain max() into
+    # NaN -> "no peak" -> factor 1 -> a silently UNDER-resolved row.
+    rowmax = xpy.max(lnL_t, axis=-1, keepdims=True)
+    contributes = lnL_t[..., 1:-1] > (rowmax - SUPPORT_NATS)
+    usable = contributes & xpy.isfinite(d2)
+    curv = xpy.max(xpy.where(usable, -d2, -xpy.inf), axis=-1)
+
+    peaked = curv > 0
+    sigma = xpy.where(peaked, 1.0 / xpy.sqrt(xpy.where(peaked, curv, 1.0)),
+                      xpy.inf)
+    return sigma, xpy.argmax(lnL_t, axis=-1)
+
+
+def _factor_per_row(sigma, dx, xpy=np):
+    """Power-of-two upsampling factor for EACH row, from that row's own width.
+
+    The criterion is per row, so the factor is derived per row rather than
+    taking the sharpest row's factor for the whole batch.
+
+    Honest about what this buys, because it is less than it sounds: it helps
+    when a batch genuinely mixes broad and sharp integrands, and at rho=10 with
+    phase marginalization it does (1772 of 10000 rows derive factor 1 and cost
+    nothing).  It does NOT rescue the loud case: at rho=40, 9404 of 10000 rows
+    derive the same factor 32, because an extrinsic point far from the source
+    still has a band-limited kappa of comparable curvature -- its peak is
+    lower, not broader.  The cost there is intrinsic to resolving the
+    integrand, and is reported rather than optimised away.
+    """
+    # sigma = inf means "nothing to resolve" -> need 0 -> factor 1.
+    # sigma = 0 means "not resolvable at ANY finite factor" -- the opposite --
+    # and must not be folded into the same branch.  It arises if a curvature of
+    # -inf ever reaches here (a -inf bin from the distance-marginalization table
+    # sitting next to a contributing one); peak_width_from_lnL masks those out,
+    # so this is defence in depth, but silently returning a small factor for an
+    # unresolvable row is exactly the failure this module exists to prevent.
+    if bool(xpy.any(sigma <= 0)):
+        raise ValueError(
+            "time-marginalization integrand has a non-positive measured width "
+            "({:.3e} s): the peak is not resolvable at any finite upsampling "
+            "factor.  Refusing to guess.".format(float(xpy.min(sigma))))
+    need = UPSAMPLE_SAFETY * dx / sigma          # sigma=inf -> 0
+    need = xpy.where(xpy.isfinite(need), need, 0.0)
+    factor = 2.0 ** xpy.ceil(xpy.log2(xpy.maximum(need, 1.0)))
+    # log2/ceil can land one step short when `need` sits just under a power of
+    # two.  Erring low here would silently under-resolve, so check the actual
+    # criterion and bump.  (Rows with sigma=inf compare False and stay at 1.)
+    factor = xpy.where(dx / factor > sigma / UPSAMPLE_SAFETY, factor * 2, factor)
+    # Test the FACTOR against the ceiling, not `need`: need=4097 rounds to 8192,
+    # so a check on `need` would let a factor through that exceeds the ceiling.
+    worst = float(xpy.max(factor))
+    if worst > UPSAMPLE_FACTOR_MAX:
+        raise ValueError(
+            "time-marginalization integrand needs an upsampling factor of {:.0f} "
+            "(sharpest sigma_t={:.3e} s vs grid spacing {:.3e} s), above "
+            "UPSAMPLE_FACTOR_MAX={}.  Refusing to return a knowingly "
+            "under-resolved integral.".format(
+                worst, float(xpy.min(sigma)), dx, UPSAMPLE_FACTOR_MAX))
+    return factor.astype(np.int64)
+
+
+def required_upsample_factor(lnL_t, dx, xpy=np):
+    """Upsampling factor needed so that ``dx/factor <= sigma_min/UPSAMPLE_SAFETY``.
+
+    Rounded UP to a power of two: FFT-friendly, and it makes every coarse
+    sample land on dense index ``j*factor``, which the tests check exactly.
+
+    Returns ``(factor, sigma_min)``.  ``sigma_min`` is ``inf`` when no row has
+    a resolvable peak, in which case the factor is 1 and the caller does no
+    interpolation at all.
+    """
+    sigma, _ = peak_width_from_lnL(lnL_t, dx, xpy=xpy)
+    finite = xpy.isfinite(sigma)
+    if not bool(xpy.any(finite)):
+        return 1, float("inf")
+    sigma_min = float(xpy.min(xpy.where(finite, sigma, xpy.inf)))
+    if not np.isfinite(sigma_min) or sigma_min <= 0:
+        return 1, sigma_min
+    # Delegates to the SAME rule the integrator uses.  There were briefly two
+    # implementations (a doubling loop here, log2+ceil there); two copies of a
+    # numeric rule drift, and one of them had an off-by-one that erred LOW.
+    factor = int(xpy.max(_factor_per_row(sigma, dx, xpy=xpy)))
+    return factor, sigma_min
+
+
+def _eval_lnL(kappa, rho_sq, loglikelihood, phase_marginalization, xpy):
+    if phase_marginalization:
+        return loglikelihood(xpy.abs(kappa), rho_sq)
+    return loglikelihood(kappa.real, rho_sq)
+
+
+def _historical_simpson_log(lnL_rows, deltaT, lnLmax, simps, xpy):
+    """The historical expression, verbatim: lnLmax + log(simps(exp(lnL-lnLmax))).
+
+    Same rule, same dx, same global offset, so wrap-exposed rows come back
+    bit-for-bit as they would have without this option.
+    """
+    if simps is None:
+        from scipy import integrate
+        simps = getattr(integrate, "simpson", None) or integrate.simps
+    return lnLmax + xpy.log(simps(xpy.exp(lnL_rows - lnLmax), dx=deltaT, axis=-1))
+
+
+def _trapezoid_log(lnL_dense, dx, lnLmax, xpy):
+    """log( trapz(exp(lnL_dense), dx) ) along the last axis, offset-stabilised.
+
+    `lnLmax` is per row.  A row that is -inf at EVERY bin has a -inf maximum,
+    and `-inf - (-inf)` is NaN -- which would propagate into the sampler's
+    weights, where -inf merely meant zero weight.  Substituting a finite offset
+    for those rows makes the arithmetic give exp(-inf)=0, sum=0, log(0)=-inf,
+    i.e. exactly what the historical global-offset path returned for them.
+    """
+    w = xpy.full(lnL_dense.shape[-1], dx, dtype=np.float64)
+    w[0] *= 0.5
+    w[-1] *= 0.5
+    safe = xpy.where(xpy.isfinite(lnLmax), lnLmax, 0.0)
+    return xpy.log(xpy.sum(w * xpy.exp(lnL_dense - safe[..., None]), axis=-1))
+
+
+def time_marginalize_bandlimited(kappa, rho_sq, deltaT, loglikelihood,
+                                 phase_marginalization=False, lnL_t=None,
+                                 simps=None, lnLmax=None, xpy=np):
+    """``log \\int dt exp(lnL(t))`` with the integrand resolved, not assumed.
+
+    Parameters
+    ----------
+    kappa : (n_rows, npts) complex
+        The accumulated data term on the coarse deltaT grid.
+    rho_sq : (n_rows, npts) or (n_rows, 1) float
+        The template self-term.  MUST be constant along the time axis -- that
+        is what makes ``lnL(t)`` a pointwise function of the band-limited
+        ``kappa(t)``.  Checked, not assumed: a future banded / slow-rotation
+        backport has a genuinely time-dependent ``rho_sq`` and must not reach
+        this code silently.
+    deltaT : float
+        The spacing the likelihood actually steps by -- one SAMPLE.  Pass it
+        explicitly; do not infer it from a ``tvals`` array.  On rift_O4c the
+        window grid is a closed-interval ``linspace``, so its spacing is
+        ``deltaT*N/(N-1)``, ~0.2% coarser than deltaT, and inferring ``dx``
+        from it would be quietly wrong.
+    loglikelihood : callable
+        ``f(kappa_real_or_abs, rho_sq) -> lnL``.  Applied on the DENSE grid, so
+        nonlinear callbacks (phase marginalization, the distance-marginalization
+        table) are handled correctly rather than approximated.
+    lnL_t : optional
+        The coarse-grid ``lnL(t)`` if the caller already computed it; saves one
+        evaluation.  Must correspond to `kappa`/`rho_sq`.
+    simps, lnLmax : optional
+        The caller's Simpson implementation and its global log-offset, used
+        verbatim for wrap-exposed rows so their values are bit-for-bit the
+        historical ones.  Supplied by the caller rather than imported here so
+        the GPU path keeps its own ``optimized_gpu_tools.simps`` and this module
+        stays backend-generic.  Falls back to ``scipy`` if omitted.
+
+    Returns
+    -------
+    lnL : (n_rows,) float
+    """
+    kappa = xpy.asarray(kappa)
+    rho_sq = xpy.asarray(rho_sq)
+    npts = kappa.shape[-1]
+
+    if rho_sq.shape[-1] != 1:
+        # Cheap, and it is the guard that stops a time-dependent self-term from
+        # being interpolated as if it were constant.
+        if not bool(xpy.all(rho_sq == rho_sq[..., :1])):
+            raise NotImplementedError(
+                "time_quadrature='bandlimited' requires a time-independent "
+                "rho_sq; this rho_sq varies along the time axis (banded / "
+                "slow-rotation response?).  The band-limited argument applies "
+                "to kappa(t) only, so that path must be handled separately.")
+    rho_col = rho_sq[..., :1]
+
+    if lnL_t is None:
+        lnL_t = _eval_lnL(kappa, rho_sq, loglikelihood, phase_marginalization, xpy)
+
+    n_rows = int(np.prod(kappa.shape[:-1])) if kappa.ndim > 1 else 1
+    k2 = kappa.reshape(n_rows, npts)
+    r2 = xpy.broadcast_to(rho_col.reshape(-1, 1), (n_rows, 1))
+    lnL2 = lnL_t.reshape(n_rows, npts)
+    if lnLmax is None:
+        lnLmax = xpy.max(lnL2)
+
+    sigma_rows, jmax = peak_width_from_lnL(lnL2, deltaT, xpy=xpy)
+    has_peak = xpy.isfinite(sigma_rows)
+
+    # --- which rows are REFINED, and which are handed back untouched ---
+    #
+    # "not refined" and "gets the historical value" are ONE predicate, not two.
+    # Keeping them separate is how a row ends up neither refined nor Simpson --
+    # e.g. a signal-free row falling through to a coarse-grid TRAPEZOID, which
+    # is a different rule from Simpson even though it interpolates nothing.
+    # With one predicate the property a reviewer can check by reading is:
+    #
+    #     a row's value differs from the historical one IF AND ONLY IF its
+    #     integrand was under-resolved.
+    #
+    # Wrap-exposed: the peak sits too near a window edge for the periodic
+    # interpolant to be trusted.  The guard only claims rows that HAVE a
+    # resolvable peak -- a signal-free row is constant, so its argmax is 0, and
+    # claiming it would report "the window is mis-centred" when it means "these
+    # samples have no signal".
+    guard = max(1, int(EDGE_GUARD_FRACTION * npts))
+    exposed = has_peak & ((jmax < guard) | (jmax >= npts - guard))
+    n_exposed = int(xpy.sum(exposed))
+    n_edge = int(xpy.sum((jmax <= 0) | (jmax >= npts - 1)))
+    n_nonfinite = int(xpy.sum(~xpy.isfinite(xpy.max(lnL2, axis=-1))))
+    n_flat = int(xpy.sum((~has_peak) & xpy.isfinite(xpy.max(lnL2, axis=-1))))
+
+    # Exposed rows are excluded from the factor derivation as well: otherwise a
+    # single mis-centred row inflates the refinement every healthy row pays for
+    # -- and, since the ceiling RAISES rather than truncating, one such row
+    # could abort a batch it is not even going to be integrated from.
+    sigma_eff = xpy.where(exposed, xpy.inf, sigma_rows)
+    sigma_min = (float(xpy.min(xpy.where(has_peak & (~exposed), sigma_eff, xpy.inf)))
+                 if bool(xpy.any(has_peak & (~exposed))) else float("inf"))
+    factor_rows = _factor_per_row(sigma_eff, deltaT, xpy=xpy)
+    factor_initial = int(xpy.max(factor_rows)) if n_rows else 1
+
+    refined = has_peak & (~exposed) & (factor_rows > 1)
+    n_refined = int(xpy.sum(refined))
+    # Rows with a peak the grid ALREADY resolves.  Counted so the five buckets
+    # partition the batch exactly -- without it a reader cannot tell "resolved,
+    # so nothing to do" from a row that fell through some gap.
+    n_resolved = int(xpy.sum(has_peak & (~exposed) & (factor_rows == 1)))
+
+    out = xpy.empty(n_rows, dtype=np.float64)
+    keep = ~refined
+    if bool(xpy.any(keep)):
+        idx = xpy.nonzero(keep)[0]
+        out[idx] = _historical_simpson_log(lnL2[idx], deltaT, lnLmax, simps, xpy)
+
+    hist, n_chunks, n_dense_max = {}, 0, 0
+    sigma_dense_min = np.inf
+
+    for f0 in sorted(set(int(x) for x in np.asarray(
+            factor_rows if xpy is np else factor_rows.get()))):
+        rows = xpy.nonzero((factor_rows == f0) & refined)[0]
+        n_g = int(rows.size)
+        if n_g == 0:
+            continue
+        kg, rg = k2[rows], r2[rows]
+        factor = f0
+        while True:
+            # Domain: exactly [t_0, t_{npts-1}], the closed interval Simpson
+            # used.  The only dense samples dropped are the factor-1 past the
+            # last coarse sample -- precisely the ones across the FFT's
+            # periodic wrap.  No interior sample is dropped.
+            n_keep = (npts - 1) * factor + 1
+            dx = deltaT / factor
+            per_row = n_keep * (16 + 8 * 6)   # dense complex row + callback temporaries
+            chunk = max(1, min(n_g, int(_DENSE_CHUNK_BYTES // max(per_row, 1))))
+            vals = xpy.empty(n_g, dtype=np.float64)
+            sd_min = np.inf
+            n_ch = 0
+            for lo in range(0, n_g, chunk):
+                hi = min(lo + chunk, n_g)
+                n_ch += 1
+                kd = bandlimited_upsample(kg[lo:hi], factor, xpy=xpy)[..., :n_keep]
+                rd = xpy.broadcast_to(rg[lo:hi], (hi - lo, n_keep))
+                lnLd = _eval_lnL(kd, rd, loglikelihood, phase_marginalization, xpy)
+                sd, _ = peak_width_from_lnL(lnLd, dx, xpy=xpy)
+                fin = xpy.isfinite(sd)
+                if bool(xpy.any(fin)):
+                    sd_min = min(sd_min,
+                                 float(xpy.min(xpy.where(fin, sd, xpy.inf))))
+                # PER-ROW offset, taken on the DENSE grid.  Both halves matter.
+                # Reusing the coarse grid's maximum overflows: under-resolution
+                # means the dense maximum can exceed it by thousands of nats, so
+                # exp(v - coarse_max) returns +inf -- and it fails precisely in
+                # the regime this option exists to fix.  Reusing the historical
+                # GLOBAL offset underflows the other way: every row more than
+                # ~745 nats below the block maximum becomes exp()=0 and then
+                # log(0) = -inf.  The expression is offset-invariant, so per-row
+                # is not a change of estimator.
+                m = xpy.max(lnLd, axis=-1)
+                # m is -inf only when the row is -inf everywhere; _trapezoid_log
+                # then returns -inf, and -inf + -inf is -inf, which is right.
+                vals[lo:hi] = m + _trapezoid_log(lnLd, dx, m, xpy)
+
+            # Re-verify on the grid actually integrated.  A coarse-grid width
+            # can be optimistic for a strongly non-Gaussian peak; this is what
+            # turns the derivation into an assertion rather than a guess.
+            if not np.isfinite(sd_min) or dx <= sd_min / UPSAMPLE_SAFETY:
+                break
+            if factor * 2 > UPSAMPLE_FACTOR_MAX:
+                raise ValueError(
+                    "time-marginalization integrand still under-resolved at "
+                    "factor={} (dense sigma_t={:.3e} s vs spacing {:.3e} s) and "
+                    "doubling would exceed UPSAMPLE_FACTOR_MAX={}.".format(
+                        factor, sd_min, dx, UPSAMPLE_FACTOR_MAX))
+            factor *= 2
+
+        out[rows] = vals
+        hist[factor] = hist.get(factor, 0) + n_g
+        n_chunks += n_ch
+        n_dense_max = max(n_dense_max, n_keep)
+        sigma_dense_min = min(sigma_dense_min, sd_min)
+
+    _LAST_REPORT.clear()
+    _LAST_REPORT.update(
+        factor=max(hist) if hist else 1,
+        factor_initial=factor_initial,
+        factor_histogram=dict(sorted(hist.items())),
+        sigma_t_min=sigma_min, sigma_t_min_dense=sigma_dense_min,
+        npts=npts, npts_dense=n_dense_max, n_rows=n_rows, n_chunks=n_chunks,
+        n_edge_peak_rows=n_edge, n_wrap_exposed_rows=n_exposed,
+        n_nonfinite_rows=n_nonfinite, n_flat_rows=n_flat,
+        n_refined_rows=n_refined, n_resolved_rows=n_resolved)
+    return out.reshape(kappa.shape[:-1])

--- a/MonteCarloMarginalizeCode/Code/bin/integrate_likelihood_extrinsic_batchmode
+++ b/MonteCarloMarginalizeCode/Code/bin/integrate_likelihood_extrinsic_batchmode
@@ -229,6 +229,7 @@ optp.add_option("-m", "--time-marginalization", action="store_true", help="Perfo
 #optp.add_option("--n-fairdraw-extrinsic-samples",default=None,type=int,help="Extracts a concrete number of fair draw extrinsic samples, bounded above by n_eff")
 optp.add_option("--resample-time-marginalization",action='store_true', help="If time-marginalizaiton is true (and should almost always be true), at the end export step use resampling. REQUIRES using fairdraw-extrinsic-output")
 optp.add_option("--srate-resample-time-marginalization",type=int, default=None, help="If time-marginalizaiton is true (and should almost always be true), an opportunity to interpolate the likelihoods on the (internal) time grid and perform time resampling at a higher sampling rate, for greater nominal time resolution. Does not change underlying calculations.")
+optp.add_option("--time-marginalization-quadrature",default='simpson',type=str,help="Quadrature rule for the time-marginalization integral: 'simpson' (default; the historical fixed-dx=deltaT Simpson rule) or 'bandlimited' (recover the continuous integrand from the samples already computed, by band-limited FFT upsampling of kappa(t), and integrate with the trapezoid rule at a DERIVED resolution). 'bandlimited' CHANGES RESULTS -- it removes a quadrature error that grows with SNR, so the louder the event the larger the change. It needs no extra likelihood evaluations and no extra precompute, but it is NOT free: evaluating the integrand on the refined grid cost 3.3x-47x the Simpson path (CPU time, whole likelihood call, --n-chunk 10000, srate 4096), rising with SNR and roughly halved by phase marginalization. See RIFT/likelihood/time_marginalization_quadrature.py.")
 optp.add_option("-d", "--distance-marginalization", action="store_true", help="Perform marginalization over distance via a look-up table. Default is false.")
 optp.add_option("-l", "--distance-marginalization-lookup-table", default=None, help="Look-up table for distance marginalization.")
 optp.add_option("--vectorized", action="store_true", help="Perform manipulations of lm and timeseries using numpy arrays, not LAL data structures.  (Combine with --gpu to enable GPU use, where available)")
@@ -495,6 +496,16 @@ if opts.nr_group and opts.nr_param:
 template_min_freq = opts.fmin_template # minimum frequency of template
 #t_ref_wind = 50e-3 # Interpolate in a window +/- this width about event time. 
 t_ref_wind = opts.data_integration_window_half
+
+# Validate the time-marginalization quadrature up front, and SAY which one is
+# running.  An opt-in flag that silently does nothing is a documented failure
+# mode in this repo; the corresponding factor actually used is reported from
+# the likelihood side via time_marginalization_quadrature.last_report().
+factored_likelihood.time_quad.validate_time_quadrature(opts.time_marginalization_quadrature)
+print(" Time-marginalization quadrature : {} {}".format(
+    opts.time_marginalization_quadrature,
+    "(historical fixed-dx Simpson rule)" if opts.time_marginalization_quadrature == 'simpson'
+    else "(band-limited upsampling + trapezoid; RESULT-CHANGING vs simpson)"))
 T_safety = 2. # Safety buffer (in sec) for wraparound corruption
 
 #
@@ -1658,7 +1669,7 @@ def analyze_event(P_list, indx_event, data_dict, psd_dict, fmax, opts,inv_spec_t
 
 
                 lnL = factored_likelihood.DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop(tvals,
-                        P, lookupNKDict, rholmArrayDict, ctUArrayDict, ctVArrayDict,epochDict,Lmax=opts.l_max,xpy=xpy_default)
+                        P, lookupNKDict, rholmArrayDict, ctUArrayDict, ctVArrayDict,epochDict,Lmax=opts.l_max,xpy=xpy_default, time_quadrature=opts.time_marginalization_quadrature)
 #                nEvals +=len(right_ascension)
                 if supplemental_ln_likelihood:
                   lnL += supplemental_ln_likelihood(P.phi, P.theta, P.phiref ,P.incl, P.psi, P.dist,xpy=xpy_default) # use these variables so they are already float-type
@@ -1761,7 +1772,7 @@ def analyze_event(P_list, indx_event, data_dict, psd_dict, fmax, opts,inv_spec_t
                     P.phiref = phi_orb_true
 
                   lnL = factored_likelihood.DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop(tvals,
-                    P, lookupNKDict, rholmArrayDict, ctUArrayDict, ctVArrayDict,epochDict,Lmax=opts.l_max,xpy=xpy_default, loglikelihood=distmarg_loglikelihood, phase_marginalization=True)
+                    P, lookupNKDict, rholmArrayDict, ctUArrayDict, ctVArrayDict,epochDict,Lmax=opts.l_max,xpy=xpy_default, loglikelihood=distmarg_loglikelihood, phase_marginalization=True, time_quadrature=opts.time_marginalization_quadrature)
 #                  nEvals +=len(right_ascension)
                   if supplemental_ln_likelihood:
                     lnL += supplemental_ln_likelihood(P.phi, P.theta, P.phiref ,P.incl, P.psi, 0,xpy=xpy_default) # Same API
@@ -1804,7 +1815,7 @@ def analyze_event(P_list, indx_event, data_dict, psd_dict, fmax, opts,inv_spec_t
                     P.phiref = phi_orb_true
 
                   lnL = factored_likelihood.DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop(tvals,
-                    P, lookupNKDict, rholmArrayDict, ctUArrayDict, ctVArrayDict,epochDict,Lmax=opts.l_max,xpy=xpy_default, loglikelihood=distmarg_loglikelihood)
+                    P, lookupNKDict, rholmArrayDict, ctUArrayDict, ctVArrayDict,epochDict,Lmax=opts.l_max,xpy=xpy_default, loglikelihood=distmarg_loglikelihood, time_quadrature=opts.time_marginalization_quadrature)
 #                  nEvals +=len(right_ascension)
                   if supplemental_ln_likelihood:
                     lnL += supplemental_ln_likelihood(P.phi, P.theta, P.phiref ,P.incl, P.psi, 0,xpy=xpy_default) # Same API

--- a/MonteCarloMarginalizeCode/Code/test/test_time_marginalization_cli.py
+++ b/MonteCarloMarginalizeCode/Code/test/test_time_marginalization_cli.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""The DRIVER, through a subprocess -- not the library.
+
+A library test cannot see the driver's option at all.  The companion `rift_O4d`
+work found an `AttributeError` in exactly this seam (a module referenced by its
+submodule name rather than by the alias the import bound), which every one of
+its library tests passed straight over and which would have broken *every*
+invocation of the driver, with or without the flag.  These tests exist so that
+seam is exercised.
+
+They only run `--help` and the startup path, so they need no data and no frames:
+the option is validated, and the banner printed, before any data is touched.
+"""
+import os
+import subprocess
+import sys
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CODE = os.path.abspath(os.path.join(HERE, ".."))
+ILE = os.path.join(CODE, "bin", "integrate_likelihood_extrinsic_batchmode")
+
+
+def _run(*args, timeout=600):
+    env = dict(os.environ)
+    env["PYTHONPATH"] = CODE + os.pathsep + env.get("PYTHONPATH", "")
+    env["OMP_NUM_THREADS"] = "1"
+    return subprocess.run([sys.executable, ILE, *args], capture_output=True,
+                          text=True, env=env, timeout=timeout)
+
+
+@pytest.fixture(scope="module")
+def help_text():
+    p = _run("--help")
+    assert p.returncode == 0, p.stderr[-3000:]
+    return p.stdout
+
+
+def test_the_option_is_registered_on_the_driver(help_text):
+    """Weakest of these, and deliberately labelled as such: `--help` exits before
+    the validation line, so this passes even with the import-alias bug the
+    companion line hit.  The three startup tests below are the ones that catch
+    it -- verified by injecting that exact bug, which fails those three and not
+    this one."""
+    assert "--time-marginalization-quadrature" in help_text
+
+
+def test_help_states_that_the_option_changes_results_and_costs_something(help_text):
+    i = help_text.index("--time-marginalization-quadrature")
+    blurb = " ".join(help_text[i:i + 1600].split())
+    assert "simpson" in blurb and "bandlimited" in blurb
+    assert "CHANGES RESULTS" in blurb
+    assert "not free" in blurb.lower() or "cost" in blurb.lower()
+
+
+def test_a_misspelled_value_is_refused_before_any_data_is_touched():
+    p = _run("--time-marginalization-quadrature", "trapezoid")
+    assert p.returncode != 0
+    combined = p.stdout + p.stderr
+    assert "time_quadrature must be one of" in combined, combined[-3000:]
+
+
+def test_the_banner_names_the_quadrature_actually_in_force():
+    """Not a silently-inert flag: the driver says which path is running."""
+    p = _run("--time-marginalization-quadrature", "bandlimited")
+    out = p.stdout + p.stderr
+    assert "Time-marginalization quadrature : bandlimited" in out, out[-3000:]
+    assert "RESULT-CHANGING" in out
+
+
+def test_the_default_is_simpson_when_the_flag_is_absent():
+    p = _run()
+    out = p.stdout + p.stderr
+    assert "Time-marginalization quadrature : simpson" in out, out[-3000:]
+    assert "historical" in out
+
+
+def test_every_marginalizing_driver_call_site_passes_the_option():
+    """A ledger over the driver's call sites, checked structurally with `ast`.
+
+    There is no cheap behavioural way to reach the three call sites -- they need
+    frames, a PSD and a precompute -- so this pins the invariant instead: every
+    call to the likelihood that actually MARGINALIZES must forward
+    time_quadrature.  A call that returns the lnL(t) timeseries is exempt,
+    because the option does not apply to it.
+
+    The failure this exists for is a new call site added later, or one of the
+    three edited, silently reverting to Simpson while the flag still parses and
+    the banner still prints.
+    """
+    import ast
+    tree = ast.parse(open(ILE).read())
+    target = "DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop"
+    sites = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            fn = node.func
+            name = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", None)
+            if name == target:
+                kw = {k.arg for k in node.keywords if k.arg}
+                sites.append((node.lineno, "return_lnLt" in kw, "time_quadrature" in kw))
+    assert sites, "no call sites found -- has the function been renamed?"
+    unwired = [ln for ln, exports, wired in sites if not exports and not wired]
+    assert not unwired, (
+        "driver call sites that marginalize but do not pass time_quadrature, "
+        "at lines %s" % unwired)
+    assert sum(1 for _, exports, wired in sites if wired) >= 3, sites

--- a/MonteCarloMarginalizeCode/Code/test/test_time_marginalization_quadrature.py
+++ b/MonteCarloMarginalizeCode/Code/test/test_time_marginalization_quadrature.py
@@ -1,0 +1,986 @@
+#!/usr/bin/env python3
+"""Tests for the band-limited time-marginalization quadrature.
+
+Two layers, deliberately:
+
+* the module in isolation, against integrands whose exact value is known in
+  closed form -- no LAL, no waveforms, deterministic, seconds to run;
+* the WIRING, i.e. that flipping ``time_quadrature`` on the shipped likelihood
+  function actually changes the number it returns.  A silently-inert opt-in
+  flag is a known failure mode in this codebase, and a test that only exercises
+  the helper would not catch one.
+"""
+import math
+
+import numpy as np
+import pytest
+
+from RIFT.likelihood import time_marginalization_quadrature as tq
+
+
+# --------------------------------------------------------------------------
+# A synthetic integrand whose continuous form is known exactly.
+#
+# kappa(t) = sum_k c_k exp(2 pi i f_k t), every f_k an exact multiple of
+# 1/(n*deltaT) with |f_k| < Nyquist.  Then kappa is band-limited AND periodic
+# on the sample window, so the DFT interpolation of its samples is not merely
+# accurate but exact -- which is precisely the claim under test.
+# --------------------------------------------------------------------------
+def _synthetic_kappa(n, deltaT, amp, t0=None, seed=7, spectrum="gaussian",
+                     n_modes=6):
+    """A band-limited, window-periodic kappa(t) whose peak sits exactly at t0.
+
+    Every frequency is an exact multiple of 1/(n*deltaT) and below Nyquist, so
+    kappa is band-limited AND periodic on the sample window: the DFT
+    interpolation of its samples is then not merely accurate but exact, which
+    is the claim under test.  The mode coefficients are real and positive, so
+    Re kappa peaks at exactly t=t0 with curvature known in closed form.
+
+    `amp` plays the role of rho^2: larger means a narrower exp(lnL(t)) against
+    the same fixed grid, i.e. exactly what a louder event does.
+
+    spectrum:
+      'gaussian' -- a smooth spectral taper over every mode, giving a single
+          dominant pulse with small side lobes.  This is the physical
+          matched-filter shape: a slowly varying envelope times a carrier.
+      'comb' -- a handful of random high frequencies and no envelope, so the
+          row is full of comparable spikes and the SAMPLED maximum need not sit
+          anywhere near the true one.  Deliberately adversarial; it exists to
+          pin the behaviour the argmax-only width rule got wrong.
+    """
+    if t0 is None:
+        t0 = 0.5 * (n - 1) * deltaT
+    rng = np.random.default_rng(seed)
+    kmax = (n - 1) // 2
+    if spectrum == "gaussian":
+        ks = np.arange(1, kmax + 1)
+        a = np.exp(-0.5 * (ks / (0.35 * kmax)) ** 2)
+    elif spectrum == "comb":
+        ks = rng.choice(np.arange(kmax // 2, kmax + 1), size=n_modes,
+                        replace=False)
+        a = rng.uniform(0.5, 1.5, size=n_modes)
+    else:
+        raise ValueError(spectrum)
+    a = a * (amp / a.sum())                 # Re kappa(t0) == amp, exactly
+    freqs = ks / (n * deltaT)
+
+    def kappa_of_t(t):
+        t = np.asarray(t, dtype=float)
+        ph = 2j * np.pi * freqs[:, None] * (t.ravel()[None, :] - t0)
+        return (a[:, None] * np.exp(ph)).sum(axis=0).reshape(t.shape)
+
+    kappa_of_t.curvature = -float((a * (2 * np.pi * freqs) ** 2).sum())
+    kappa_of_t.t0 = t0
+    kappa_of_t.amp = amp
+    return kappa_of_t
+
+
+def _helper(kappa_real, rho_sq):
+    """The shipped default loglikelihood callback."""
+    return kappa_real - 0.5 * rho_sq
+
+
+def _log_trapz(t, lnL):
+    m = lnL.max()
+    return m + math.log(np.trapz(np.exp(lnL - m), t))
+
+
+def _reference_log_integral(kappa_of_t, rho_sq, t_grid, oversample=257,
+                            lnL_of=None):
+    """log int exp(lnL) dt over [t_grid[0], t_grid[-1]], from the ANALYTIC kappa.
+
+    Independent of the module: it never touches an FFT, it evaluates the closed
+    form on a grid `oversample` times finer (a prime factor, so it shares no
+    nodes with any power-of-two factor the module might pick).
+
+    Returns ``(value, err)``, where `err` is the reference's OWN convergence
+    estimate -- the shift between this resolution and half of it.  Tests
+    compare against `err` rather than a hardcoded tolerance, so a test can
+    never be tighter than the truth it is checking against.
+    """
+    if lnL_of is None:
+        lnL_of = lambda t: kappa_of_t(t).real - 0.5 * rho_sq
+    t = np.linspace(t_grid[0], t_grid[-1], (len(t_grid) - 1) * oversample + 1)
+    fine = _log_trapz(t, lnL_of(t))
+    coarse = _log_trapz(t[::2], lnL_of(t[::2]))
+    return fine, abs(fine - coarse)
+
+
+def _simpson_log_integral(kappa_of_t, rho_sq, t_grid):
+    """What the historical path computes: Simpson at dx=deltaT on the samples."""
+    from scipy import integrate
+    simps = getattr(integrate, "simpson", None) or integrate.simps
+    lnL = kappa_of_t(t_grid).real - 0.5 * rho_sq
+    m = lnL.max()
+    return m + math.log(simps(np.exp(lnL - m), dx=t_grid[1] - t_grid[0]))
+
+
+# --------------------------------------------------------------------------
+# bandlimited_upsample
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("n", [64, 65, 128, 127])
+@pytest.mark.parametrize("factor", [2, 4, 8])
+def test_upsample_is_exact_on_a_band_limited_signal(n, factor):
+    """The whole fix rests on this: the samples already determine the continuum."""
+    deltaT = 1.0 / 512
+    kap = _synthetic_kappa(n, deltaT, amp=3.0)
+    t = np.arange(n) * deltaT
+    dense = tq.bandlimited_upsample(kap(t)[None, :], factor)[0]
+    t_dense = np.arange(n * factor) * (deltaT / factor)
+    assert np.allclose(dense, kap(t_dense), rtol=0, atol=1e-10 * np.abs(kap(t)).max())
+
+
+@pytest.mark.parametrize("n", [64, 65])
+def test_upsample_preserves_the_original_samples_at_stride_factor(n):
+    deltaT = 1.0 / 512
+    kap = _synthetic_kappa(n, deltaT, amp=3.0)
+    x = kap(np.arange(n) * deltaT)
+    dense = tq.bandlimited_upsample(x[None, :], 8)[0]
+    assert np.allclose(dense[::8], x, rtol=0, atol=1e-12 * np.abs(x).max())
+
+
+def test_upsample_factor_one_is_a_no_op():
+    x = np.arange(10, dtype=complex)[None, :]
+    assert tq.bandlimited_upsample(x, 1) is x
+
+
+def test_upsample_rejects_a_nonpositive_factor():
+    with pytest.raises(ValueError):
+        tq.bandlimited_upsample(np.zeros((1, 8), dtype=complex), 0)
+
+
+# --------------------------------------------------------------------------
+# peak_width_from_lnL -- the estimator the derived factor rests on
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("sigma_over_h", [4.0, 1.0, 0.3, 0.1, 0.03])
+@pytest.mark.parametrize("offset", [0.0, 0.17, 0.5, -0.41])
+def test_peak_width_is_exact_for_a_gaussian_at_any_resolution_and_phase(
+        sigma_over_h, offset):
+    """A quadratic's second difference is its second derivative at ANY spacing.
+
+    This is why a peak the grid cannot resolve can still report its own width
+    honestly, which is what lets the factor be derived rather than guessed.
+    The badly under-resolved cases (0.1, 0.03) are the ones that matter: they
+    are the production regime this change exists to fix.
+    """
+    n, dx = 201, 1.0
+    sigma = sigma_over_h * dx
+    t = (np.arange(n) - n // 2) * dx
+    lnL = -0.5 * ((t - offset * dx) / sigma) ** 2
+    sig, _ = tq.peak_width_from_lnL(lnL[None, :], dx)
+    assert sig[0] == pytest.approx(sigma, rel=1e-10)
+
+
+def test_peak_width_is_infinite_for_a_flat_integrand():
+    lnL = np.zeros((1, 51))
+    sig, _ = tq.peak_width_from_lnL(lnL, 1.0)
+    assert not np.isfinite(sig[0])
+
+
+def test_peak_width_handles_a_peak_at_the_array_edge():
+    """argmax at index 0 must not index out of bounds."""
+    lnL = -np.arange(31.0)[None, :]
+    sig, j = tq.peak_width_from_lnL(lnL, 1.0)
+    assert j[0] == 0 and np.isfinite(sig).size == 1
+
+
+def test_peak_width_rejects_too_few_samples():
+    with pytest.raises(ValueError):
+        tq.peak_width_from_lnL(np.zeros((1, 2)), 1.0)
+
+
+# --------------------------------------------------------------------------
+# required_upsample_factor -- derived, power of two, and it refuses rather
+# than truncating
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("sigma_over_h", [8.0, 1.0, 0.25, 0.05, 0.01])
+def test_required_factor_meets_the_criterion_and_is_a_power_of_two(sigma_over_h):
+    n, dx = 201, 1.0
+    sigma = sigma_over_h * dx
+    t = (np.arange(n) - n // 2) * dx
+    lnL = -0.5 * (t / sigma) ** 2
+    factor, sigma_min = tq.required_upsample_factor(lnL[None, :], dx)
+    assert factor & (factor - 1) == 0, "factor must be a power of two"
+    assert dx / factor <= sigma_min / tq.UPSAMPLE_SAFETY
+    # and not wastefully large: one step down must FAIL the criterion
+    if factor > 1:
+        assert dx / (factor // 2) > sigma_min / tq.UPSAMPLE_SAFETY
+
+
+def test_required_factor_is_one_when_nothing_needs_resolving():
+    factor, sigma = tq.required_upsample_factor(np.zeros((3, 51)), 1.0)
+    assert factor == 1 and not np.isfinite(sigma)
+
+
+def test_required_factor_is_set_by_the_SHARPEST_row():
+    n, dx = 201, 1.0
+    t = (np.arange(n) - n // 2) * dx
+    broad = -0.5 * (t / (4.0 * dx)) ** 2
+    sharp = -0.5 * (t / (0.05 * dx)) ** 2
+    f_broad, _ = tq.required_upsample_factor(broad[None, :], dx)
+    f_both, _ = tq.required_upsample_factor(np.stack([broad, sharp]), dx)
+    f_sharp, _ = tq.required_upsample_factor(sharp[None, :], dx)
+    assert f_both == f_sharp > f_broad
+
+
+def test_required_factor_raises_rather_than_truncating():
+    """A cap that silently clamps would hand back a knowingly wrong integral."""
+    n, dx = 201, 1.0
+    t = (np.arange(n) - n // 2) * dx
+    lnL = -0.5 * (t / (1.0e-5 * dx)) ** 2
+    with pytest.raises(ValueError, match="UPSAMPLE_FACTOR_MAX"):
+        tq.required_upsample_factor(lnL[None, :], dx)
+
+
+# --------------------------------------------------------------------------
+# validate_time_quadrature
+# --------------------------------------------------------------------------
+def test_validate_accepts_the_documented_choices_and_rejects_others():
+    for choice in tq.TIME_QUADRATURE_CHOICES:
+        assert tq.validate_time_quadrature(choice) == choice
+    for bad in ("Simpson", "trapezoid", "bandlimited ", None, 8):
+        with pytest.raises(ValueError):
+            tq.validate_time_quadrature(bad)
+
+
+# --------------------------------------------------------------------------
+# time_marginalize_bandlimited against a closed-form integrand
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("amp", [4.0, 40.0, 400.0])
+def test_bandlimited_beats_simpson_against_the_analytic_integral(amp):
+    """The headline claim, at three peak sharpnesses.
+
+    `amp` plays the role of rho^2: the larger it is, the narrower exp(lnL(t))
+    becomes against the fixed grid, and the worse the historical Simpson rule
+    does.  The band-limited path must stay accurate where Simpson does not.
+    Tolerance is the REFERENCE's own convergence estimate, not a constant.
+    """
+    n, deltaT = 128, 1.0 / 4096
+    kap = _synthetic_kappa(n, deltaT, amp=amp)
+    t = np.arange(n) * deltaT
+    rho_sq = amp
+    truth, ref_err = _reference_log_integral(kap, rho_sq, t)
+    simpson = _simpson_log_integral(kap, rho_sq, t)
+    band = tq.time_marginalize_bandlimited(
+        kap(t)[None, :], np.full((1, n), rho_sq), deltaT, _helper)[0]
+
+    tol = max(10 * ref_err, 1e-9)
+    assert abs(band - truth) < tol, (band, truth, ref_err)
+    assert abs(band - truth) < abs(simpson - truth)
+
+
+def test_synthetic_peak_width_matches_the_closed_form_curvature():
+    """Guards the fixture: if its peak is not where and as sharp as it claims,
+    every tolerance built on it is meaningless."""
+    n, deltaT, amp = 128, 1.0 / 4096, 200.0
+    kap = _synthetic_kappa(n, deltaT, amp=amp)
+    t = np.arange(n) * deltaT
+    lnL = kap(t).real - 0.5 * amp
+    assert t[np.argmax(lnL)] == pytest.approx(kap.t0, abs=deltaT)
+    sigma_exact = 1.0 / math.sqrt(-kap.curvature)
+    sig, _ = tq.peak_width_from_lnL(lnL[None, :], deltaT)
+    assert 0.5 < sig[0] / sigma_exact < 2.0, (sig[0], sigma_exact)
+
+
+def test_width_is_taken_from_the_sharpest_feature_not_the_tallest_sample():
+    """The width used must be the sharpest feature's, not the argmax's.
+
+    On a comb the true peak can fall midway between samples, so the SAMPLED
+    maximum need not sit near it.  Measured honestly, the two rules agree on
+    every case constructed here -- an A/B over both spectra, three amplitudes,
+    25 seeds and five sub-sample offsets found no difference in the resulting
+    integral.  So this pins the conservative property (the width used is never
+    larger than the argmax reading, hence the grid is never coarser) and the
+    outcome that actually matters (the integral is right), without claiming the
+    argmax rule was observed to fail.
+    """
+    n, deltaT, amp = 128, 1.0 / 4096, 200.0
+    kap = _synthetic_kappa(n, deltaT, amp=amp, spectrum="comb")
+    t = np.arange(n) * deltaT
+    lnL = kap(t).real - 0.5 * amp
+    # the premise: the sampled argmax really is not the true peak here
+    assert abs(t[np.argmax(lnL)] - kap.t0) > deltaT
+
+    j = int(np.argmax(lnL))
+    d2_at_argmax = (lnL[j - 1] - 2 * lnL[j] + lnL[j + 1]) / deltaT ** 2
+    sigma_argmax = 1.0 / math.sqrt(-d2_at_argmax)
+    sigma_used, _ = tq.peak_width_from_lnL(lnL[None, :], deltaT)
+    assert sigma_used[0] <= sigma_argmax
+
+    truth, ref_err = _reference_log_integral(kap, amp, t)
+    band = tq.time_marginalize_bandlimited(
+        kap(t)[None, :], np.full((1, n), amp), deltaT, _helper)[0]
+    assert abs(band - truth) < max(10 * ref_err, 1e-9), (band, truth, ref_err)
+
+
+def test_bandlimited_is_insensitive_to_grid_phase_where_simpson_is_not():
+    """The defect's signature is that the answer moves when the PEAK moves.
+
+    Sliding the peak by up to two samples about the window centre cannot change
+    the continuous integral -- and that is asserted here on the analytic
+    reference first, so the test cannot pass by comparing two broken things.
+    Simpson's answer moves anyway; the band-limited answer must not.
+    """
+    n, deltaT, amp = 128, 1.0 / 4096, 200.0
+    t = np.arange(n) * deltaT
+    centre = 0.5 * (n - 1) * deltaT
+    ref_vals, simps_vals, band_vals = [], [], []
+    for shift in np.linspace(-deltaT, deltaT, 9):
+        kap = _synthetic_kappa(n, deltaT, amp=amp, t0=centre + shift)
+        ref, _ = _reference_log_integral(kap, amp, t)
+        ref_vals.append(ref)
+        simps_vals.append(_simpson_log_integral(kap, amp, t))
+        band_vals.append(tq.time_marginalize_bandlimited(
+            kap(t)[None, :], np.full((1, n), amp), deltaT, _helper)[0])
+    span = lambda v: max(v) - min(v)
+    assert span(ref_vals) < 1e-6, span(ref_vals)     # the truth IS invariant
+    assert span(simps_vals) > 1.0, span(simps_vals)  # the defect is present
+    assert span(band_vals) < 1e-6, span(band_vals)   # and the fix removes it
+
+
+def test_a_resolved_row_comes_back_byte_equal_to_simpson():
+    """The property the whole design now rests on: a row's value differs from
+    the historical one IF AND ONLY IF its integrand was under-resolved.
+
+    A row the grid already resolves derives factor 1, is not refined, and is
+    returned untouched -- not re-integrated with a different rule.
+    """
+    n, deltaT, amp = 65, 1.0, 0.05
+    kap = _synthetic_kappa(n, deltaT, amp=amp)      # deliberately very broad
+    t = np.arange(n) * deltaT
+    K, R = kap(t)[None, :], np.full((1, n), amp)
+    got = tq.time_marginalize_bandlimited(K, R, deltaT, _helper)
+    rep = tq.last_report()
+    assert rep["n_refined_rows"] == 0
+    assert np.array_equal(got, _simpson_rows((K[0].real - 0.5 * amp)[None, :], deltaT))
+
+
+def test_bandlimited_integrates_the_same_domain_as_simpson():
+    """Domain, not just spacing: the dense grid must span [t_0, t_{npts-1}].
+
+    An edge taper would shrink it instead, which is invisible for a sharp
+    interior peak and a real error for a broad one.
+    """
+    n, deltaT, amp = 128, 1.0 / 4096, 200.0
+    kap = _synthetic_kappa(n, deltaT, amp=amp)      # sharp enough to be refined
+    t = np.arange(n) * deltaT
+    tq.time_marginalize_bandlimited(kap(t)[None, :], np.full((1, n), amp),
+                                    deltaT, _helper)
+    rep = tq.last_report()
+    assert rep["n_refined_rows"] == 1 and rep["n_wrap_exposed_rows"] == 0
+    assert rep["npts_dense"] == (rep["npts"] - 1) * rep["factor"] + 1
+
+
+# --------------------------------------------------------------------------
+# the wrap guard: no row may come out worse than the status quo
+# --------------------------------------------------------------------------
+def _simpson_rows(lnL_rows, deltaT):
+    from scipy import integrate
+    simps = getattr(integrate, "simpson", None) or integrate.simps
+    m = lnL_rows.max()
+    return m + np.log(simps(np.exp(lnL_rows - m), dx=deltaT, axis=-1))
+
+
+def test_wrap_exposed_rows_get_the_historical_value_bit_for_bit():
+    """The FFT interpolant is periodic, so a peak beside the wrap is not merely
+    inaccurate but wrong HIGH -- which would importance-weight that sample into
+    dominance.  Such rows fall back, exactly, rather than being repaired."""
+    n, deltaT, amp = 128, 1.0 / 4096, 200.0
+    t = np.arange(n) * deltaT
+    kap = _synthetic_kappa(n, deltaT, amp=amp, t0=2 * deltaT)   # hard against the edge
+    lnL = (kap(t).real - 0.5 * amp)[None, :]
+    got = tq.time_marginalize_bandlimited(
+        kap(t)[None, :], np.full((1, n), amp), deltaT, _helper)
+    assert tq.last_report()["n_wrap_exposed_rows"] == 1
+    assert np.array_equal(got, _simpson_rows(lnL, deltaT))
+
+
+def test_the_guard_uses_the_callers_simpson_and_offset():
+    """Bit-for-bit means the CALLER's rule and offset, not a private copy: the
+    GPU build integrates with optimized_gpu_tools.simps."""
+    n, deltaT, amp = 128, 1.0 / 4096, 200.0
+    t = np.arange(n) * deltaT
+    kap = _synthetic_kappa(n, deltaT, amp=amp, t0=2 * deltaT)
+    calls = []
+
+    def spy(x, dx, axis=-1):
+        from scipy import integrate
+        simps = getattr(integrate, "simpson", None) or integrate.simps
+        calls.append(dx)
+        return simps(x, dx=dx, axis=axis)
+
+    tq.time_marginalize_bandlimited(
+        kap(t)[None, :], np.full((1, n), amp), deltaT, _helper, simps=spy)
+    assert calls == [deltaT]
+
+
+def test_exposed_rows_do_not_inflate_the_factor_for_healthy_rows():
+    """One mis-centred row must not make every healthy row pay for refinement
+    it does not need."""
+    n, deltaT, amp = 128, 1.0 / 4096, 200.0
+    t = np.arange(n) * deltaT
+    centre = _synthetic_kappa(n, deltaT, amp=30.0)                 # broad, interior
+    edge = _synthetic_kappa(n, deltaT, amp=amp, t0=1 * deltaT)     # sharp, exposed
+    K = np.stack([centre(t), edge(t)])
+    R = np.stack([np.full(n, 30.0), np.full(n, amp)])
+    tq.time_marginalize_bandlimited(K, R, deltaT, _helper)
+    rep = tq.last_report()
+    assert rep["n_wrap_exposed_rows"] == 1
+    alone = tq.required_upsample_factor(
+        (centre(t).real - 15.0)[None, :], deltaT)[0]
+    assert rep["factor"] == alone
+
+
+def test_the_guard_also_covers_the_no_refinement_path():
+    """If every row is exposed there is no dense grid at all, and the rows must
+    still come back as SIMPSON -- not as a coarse trapezoid, which would be a
+    different rule and measurably worse on an under-resolved peak."""
+    n, deltaT, amp = 128, 1.0 / 4096, 200.0
+    t = np.arange(n) * deltaT
+    kaps = [_synthetic_kappa(n, deltaT, amp=amp, t0=j * deltaT) for j in (1, 2)]
+    K = np.stack([k(t) for k in kaps])
+    R = np.full((2, n), amp)
+    lnL = np.stack([k(t).real - 0.5 * amp for k in kaps])
+    got = tq.time_marginalize_bandlimited(K, R, deltaT, _helper)
+    rep = tq.last_report()
+    assert rep["n_wrap_exposed_rows"] == 2 and rep["npts_dense"] == 0
+    assert np.array_equal(got, _simpson_rows(lnL, deltaT))
+
+
+# --------------------------------------------------------------------------
+# numerical robustness in the regime the fix exists for
+# --------------------------------------------------------------------------
+def test_no_overflow_when_the_dense_peak_towers_over_the_coarse_one():
+    """Under-resolution MEANS the dense maximum can exceed the coarse one by
+    thousands of nats.  Offsetting by the coarse maximum would overflow to +inf
+    exactly where this option is supposed to help."""
+    n, deltaT = 256, 1.0 / 4096
+    amp = 4000.0
+    kap = _synthetic_kappa(n, deltaT, amp=amp)
+    t = np.arange(n) * deltaT
+    coarse_max = (kap(t).real - 0.5 * amp).max()
+    got = tq.time_marginalize_bandlimited(
+        kap(t)[None, :], np.full((1, n), amp), deltaT, _helper)[0]
+    assert np.isfinite(got)
+    assert got > coarse_max - 50, (got, coarse_max)
+
+
+def test_rows_far_below_the_block_maximum_do_not_underflow_to_minus_inf():
+    """A single global offset makes every row more than ~745 nats down return
+    log(0) = -inf.  Per-row offsets do not."""
+    n, deltaT = 128, 1.0 / 4096
+    loud = _synthetic_kappa(n, deltaT, amp=2000.0)
+    quiet = _synthetic_kappa(n, deltaT, amp=3.0, seed=5)
+    t = np.arange(n) * deltaT
+    K = np.stack([loud(t), quiet(t)])
+    R = np.array([np.full(n, 2000.0), np.full(n, 3.0)])
+    got = tq.time_marginalize_bandlimited(K, R, deltaT, _helper)
+    assert np.all(np.isfinite(got)), got
+
+
+def test_minus_inf_in_lnL_does_not_silently_collapse_the_factor():
+    """distmarg_loglikelihood returns -inf outside its table, and
+    (-inf) - 2(-inf) + (-inf) is NaN.  A plain max() over that is NaN, which
+    reads as 'no peak' and would leave the row UNDER-resolved with no warning.
+    """
+    n, dx = 201, 1.0
+    t = (np.arange(n) - n // 2) * dx
+    lnL = -0.5 * (t / (0.05 * dx)) ** 2
+    lnL[:20] = -np.inf
+    lnL[-20:] = -np.inf
+    sigma, _ = tq.peak_width_from_lnL(lnL[None, :], dx)
+    assert np.isfinite(sigma[0])
+    assert sigma[0] == pytest.approx(0.05 * dx, rel=1e-6)
+
+
+def test_tail_noise_cannot_drive_the_factor():
+    """The curvature scan must see only bins that can affect the integral.
+
+    Otherwise numerical noise 300 nats down -- where the integrand is e^-300 --
+    sets the resolution for the whole group, and can reach the raising ceiling
+    on a row that contributes nothing.
+    """
+    n, dx = 401, 1.0
+    t = (np.arange(n) - n // 2) * dx
+    lnL = -0.5 * (t / (2.0 * dx)) ** 2                  # broad, well resolved
+    rng = np.random.default_rng(0)
+    lnL[:50] += -1.0e3 + 1.0e2 * rng.normal(size=50)    # violent junk in the tail
+    factor, _ = tq.required_upsample_factor(lnL[None, :], dx)
+    assert factor == 1, factor
+
+
+def test_bandlimited_refuses_a_time_dependent_rho_sq():
+    """The band-limited argument is about kappa(t) only.
+
+    rift_O4c has no banded / slow-rotation path today, which is exactly why
+    this guard matters: it is what stops a future backport whose rho_sq DOES
+    vary in time from being interpolated as though it did not.
+    """
+    n = 32
+    rho = np.tile(np.arange(n, dtype=float), (2, 1))
+    with pytest.raises(NotImplementedError, match="time-independent"):
+        tq.time_marginalize_bandlimited(
+            np.zeros((2, n), dtype=complex), rho, 1.0, _helper)
+
+
+def test_bandlimited_accepts_a_nonlinear_loglikelihood_callback():
+    """Production runs pass distmarg_loglikelihood, not the affine helper.
+
+    The callback is applied AFTER upsampling, so a nonlinear one is handled
+    exactly rather than approximated -- and the resolution is derived from
+    lnL(t), which already includes it.  A rule built on kappa's curvature would
+    be right only for the affine helper.
+    """
+    n, deltaT, amp = 128, 1.0 / 4096, 200.0
+    kap = _synthetic_kappa(n, deltaT, amp=amp)
+    t = np.arange(n) * deltaT
+    # a deliberately nonlinear, monotone callback
+    nl = lambda k, r: np.log1p(np.exp(np.clip(k - 0.5 * r, -700, 700)))
+    truth, ref_err = _reference_log_integral(
+        kap, amp, t, lnL_of=lambda tt: nl(kap(tt).real, amp))
+    band = tq.time_marginalize_bandlimited(
+        kap(t)[None, :], np.full((1, n), amp), deltaT, nl)[0]
+    assert abs(band - truth) < max(10 * ref_err, 1e-9), (band, truth, ref_err)
+
+
+def test_bandlimited_handles_phase_marginalization_absolute_value():
+    n, deltaT, amp = 128, 1.0 / 4096, 200.0
+    kap = _synthetic_kappa(n, deltaT, amp=amp)
+    t = np.arange(n) * deltaT
+    truth, ref_err = _reference_log_integral(
+        kap, amp, t, lnL_of=lambda tt: np.abs(kap(tt)) - 0.5 * amp)
+    band = tq.time_marginalize_bandlimited(
+        kap(t)[None, :], np.full((1, n), amp), deltaT, _helper,
+        phase_marginalization=True)[0]
+    assert abs(band - truth) < max(10 * ref_err, 1e-9), (band, truth, ref_err)
+
+
+def test_chunking_cannot_change_the_answer(monkeypatch):
+    n, deltaT, amp = 128, 1.0 / 4096, 200.0
+    kap = _synthetic_kappa(n, deltaT, amp=amp)
+    t = np.arange(n) * deltaT
+    K = np.repeat(kap(t)[None, :], 9, axis=0)
+    R = np.full((9, n), amp)
+    whole = tq.time_marginalize_bandlimited(K, R, deltaT, _helper)
+    assert tq.last_report()["n_chunks"] == 1
+    monkeypatch.setattr(tq, "_DENSE_CHUNK_BYTES", 1)
+    chunked = tq.time_marginalize_bandlimited(K, R, deltaT, _helper)
+    assert tq.last_report()["n_chunks"] == 9
+    assert np.allclose(whole, chunked, rtol=0, atol=1e-12)
+
+
+def test_report_counts_rows_whose_peak_abuts_the_window_edge():
+    """Reported, not repaired: a mis-centred window is a different defect."""
+    n = 64
+    ramp = -np.arange(n, dtype=float)
+    interior = -((np.arange(n) - n // 2) ** 2).astype(float)
+    tq.time_marginalize_bandlimited(
+        np.zeros((2, n), dtype=complex), np.zeros((2, n)), 1.0, _helper,
+        lnL_t=np.stack([ramp, interior]))
+    assert tq.last_report()["n_edge_peak_rows"] == 1
+
+
+def test_per_row_factor_meets_the_criterion_across_the_whole_usable_range():
+    """Exhaustive sweep, because this is the one number that decides accuracy.
+
+    The factor comes from `2**ceil(log2(need))`, and ceil/log2 can land one step
+    short when `need` sits just under a power of two.  Erring LOW there would
+    silently under-resolve, so the implementation re-checks the criterion and
+    bumps.  Half a million widths spanning the entire range the ceiling allows,
+    plus the no-peak case.
+    """
+    dx = 1.0 / 4096
+    lo = tq.UPSAMPLE_SAFETY * dx / tq.UPSAMPLE_FACTOR_MAX
+    sigma = np.concatenate([np.logspace(np.log10(lo * 1.001), -1, 500000),
+                            np.full(10, np.inf)])
+    factor = tq._factor_per_row(sigma, dx)
+    finite = np.isfinite(sigma)
+    with np.errstate(divide="ignore"):
+        assert np.all((dx / factor <= sigma / tq.UPSAMPLE_SAFETY) | ~finite)
+        # never more than one power of two above what is needed, either
+        assert not np.any(finite & (factor > 1) &
+                          (dx / (factor // 2) <= sigma / tq.UPSAMPLE_SAFETY))
+    assert np.all(factor & (factor - 1) == 0)
+    assert factor.max() <= tq.UPSAMPLE_FACTOR_MAX
+    assert np.all(factor[~finite] == 1)
+
+
+def test_the_ceiling_is_tested_against_the_factor_not_the_raw_requirement():
+    """`need` just above the ceiling rounds UP to twice it, so a check on `need`
+    would pass a factor that exceeds the ceiling."""
+    dx = 1.0
+    just_over = tq.UPSAMPLE_SAFETY * dx / (tq.UPSAMPLE_FACTOR_MAX + 1.0)
+    with pytest.raises(ValueError, match="UPSAMPLE_FACTOR_MAX"):
+        tq._factor_per_row(np.array([just_over]), dx)
+    # and the largest width that IS representable is accepted
+    ok = tq.UPSAMPLE_SAFETY * dx / tq.UPSAMPLE_FACTOR_MAX
+    assert int(tq._factor_per_row(np.array([ok]), dx)[0]) == tq.UPSAMPLE_FACTOR_MAX
+
+
+def test_accepts_the_input_shapes_its_contract_implies():
+    """1-D (single row), 2-D, and a rho_sq given as one column rather than
+    broadcast across time must all give the same answer.
+
+    The 1-D branch exists in the code, so it is either supported or it is dead;
+    this makes it the former.  The single-column rho_sq is what a caller would
+    naturally pass once it knows the self-term is time-independent.
+    """
+    n, deltaT, amp = 128, 1.0 / 4096, 200.0
+    kap = _synthetic_kappa(n, deltaT, amp=amp)
+    t = np.arange(n) * deltaT
+    one_d = tq.time_marginalize_bandlimited(kap(t), np.full(n, amp), deltaT, _helper)
+    two_d = tq.time_marginalize_bandlimited(kap(t)[None, :], np.full((1, n), amp),
+                                            deltaT, _helper)
+    rho_col = tq.time_marginalize_bandlimited(kap(t)[None, :], np.full((1, 1), amp),
+                                              deltaT, _helper)
+    assert np.shape(one_d) == () and np.shape(two_d) == (1,)
+    assert float(one_d) == float(two_d[0]) == float(rho_col[0])
+
+
+# --------------------------------------------------------------------------
+# Why the wrap guard exists, measured on THIS line rather than cited.
+#
+# `_synthetic_kappa` is exactly periodic on the window by construction (every
+# frequency an exact multiple of 1/(n*deltaT)), which is what makes the DFT
+# interpolation exact -- and also means it can NEVER exhibit wrap ringing.  A
+# guard test built on it would pass without demonstrating the guard is needed.
+# This fixture is band-limited but NOT periodic: incommensurate frequencies
+# under a Gaussian envelope, so a peak near one edge leaves the interpolant
+# genuinely discontinuous across the wrap.
+# --------------------------------------------------------------------------
+_NONPERIODIC_ENV = 6.0e-3
+
+
+def _nonperiodic_kappa(n, deltaT, amp, t0, seed=4, n_modes=6):
+    rng = np.random.default_rng(seed)
+    f = rng.uniform(200.0, 1500.0, size=n_modes)      # not multiples of 1/(n*dt)
+    a = rng.uniform(0.5, 1.5, size=n_modes)
+    a = a * (amp / a.sum())
+
+    def kappa_of_t(t):
+        t = np.asarray(t, dtype=float)
+        d = t.ravel() - t0
+        z = (a[:, None] * np.exp(2j * np.pi * f[:, None] * d[None, :])).sum(axis=0)
+        return (z * np.exp(-0.5 * (d / _NONPERIODIC_ENV) ** 2)).reshape(t.shape)
+
+    return kappa_of_t
+
+
+@pytest.mark.parametrize("bins_from_edge,bound", [(64, 1e-6), (40, 1e-6), (32, 1e-2)])
+def test_wrap_contamination_is_negligible_OUTSIDE_the_guard_band(
+        bins_from_edge, bound, monkeypatch):
+    """What justifies EDGE_GUARD_FRACTION: outside it the ringing does not matter.
+
+    Measured with the guard disabled, against the analytic integrand.  The
+    guard band is 0.125*256 = 32 bins here, so 32 is the boundary case.
+    """
+    n, deltaT, amp = 256, 1.0 / 4096, 400.0
+    t = np.arange(n) * deltaT
+    kap = _nonperiodic_kappa(n, deltaT, amp, t0=bins_from_edge * deltaT)
+    truth, ref_err = _reference_log_integral(kap, amp, t)
+    monkeypatch.setattr(tq, "EDGE_GUARD_FRACTION", 0.0)
+    got = tq.time_marginalize_bandlimited(
+        kap(t)[None, :], np.full((1, n), amp), deltaT, _helper)[0]
+    assert tq.last_report()["n_wrap_exposed_rows"] == 0
+    assert abs(got - truth) < max(bound, 10 * ref_err), (got, truth)
+
+
+def test_wrap_contamination_is_large_and_HIGH_inside_the_guard_band(monkeypatch):
+    """And inside it, it does matter -- and errs in the dangerous direction.
+
+    A spuriously HIGH lnL biases the evidence up and importance-weights that
+    sample into dominance, which is why these rows fall back rather than being
+    trusted.  (The companion rift_O4d measurement, with a sharper peak, reached
+    +88.8 nats; the magnitude depends on the peak, the sign does not.)
+    """
+    n, deltaT, amp = 256, 1.0 / 4096, 400.0
+    t = np.arange(n) * deltaT
+    kap = _nonperiodic_kappa(n, deltaT, amp, t0=2 * deltaT)
+    truth, _ = _reference_log_integral(kap, amp, t)
+    monkeypatch.setattr(tq, "EDGE_GUARD_FRACTION", 0.0)
+    unguarded = tq.time_marginalize_bandlimited(
+        kap(t)[None, :], np.full((1, n), amp), deltaT, _helper)[0]
+    assert unguarded - truth > 0.1, unguarded - truth        # large, and HIGH
+    monkeypatch.undo()
+    guarded = tq.time_marginalize_bandlimited(
+        kap(t)[None, :], np.full((1, n), amp), deltaT, _helper)
+    assert tq.last_report()["n_wrap_exposed_rows"] == 1
+    assert np.array_equal(guarded,
+                          _simpson_rows((kap(t).real - 0.5 * amp)[None, :], deltaT))
+
+
+def test_a_row_that_is_minus_inf_everywhere_returns_minus_inf_not_nan():
+    """Per-row offsets make `-inf - (-inf)` reachable, and NaN is far worse than
+    -inf here: -inf means zero weight, NaN propagates through the sampler.
+
+    The distance-marginalization callback returns -inf outside its table, so a
+    row entirely outside it is not hypothetical.  The historical global-offset
+    path returned -inf for such a row; so must this one.
+    """
+    n, deltaT = 64, 1.0
+    dead = np.full(n, -np.inf)
+    live = -0.01 * (np.arange(n) - n // 2).astype(float) ** 2
+    lnL = np.stack([dead, live])
+    # a callback that reproduces lnL from a zero kappa, so the dense grid is
+    # -inf on row 0 as well
+    cb = lambda k, r: np.where(np.asarray(r) > 0.5, -np.inf, np.asarray(k).real)
+    K = np.zeros((2, n), dtype=complex)
+    K[1] = live
+    R = np.stack([np.ones(n), np.zeros(n)])
+    got = tq.time_marginalize_bandlimited(K, R, deltaT, cb, lnL_t=lnL)
+    assert not np.any(np.isnan(got)), got
+    assert np.isneginf(got[0])
+    assert np.isfinite(got[1])
+
+
+def test_report_splits_the_unrefined_population():
+    """`n_refined_rows` is exactly the set of rows whose value moved.  The rest
+    are unrefined for three distinct reasons that a bare factor histogram cannot
+    tell apart -- and two of them are "this row was skipped" wearing the costume
+    of "this row was cheap".
+    """
+    n, deltaT, amp = 128, 1.0 / 4096, 200.0
+    t = np.arange(n) * deltaT
+    dead = np.full(n, -np.inf)                                  # unmeasurable
+    edge = _synthetic_kappa(n, deltaT, amp=amp, t0=1 * deltaT)  # wrap exposed
+    sharp = _synthetic_kappa(n, deltaT, amp=amp)                # refined
+    broad = _synthetic_kappa(n, deltaT, amp=0.05, seed=3)       # already resolved
+    lnL = np.stack([dead,
+                    edge(t).real - 0.5 * amp,
+                    sharp(t).real - 0.5 * amp,
+                    broad(t).real - 0.5 * 0.05])
+    K = np.stack([np.zeros(n, dtype=complex), edge(t), sharp(t), broad(t)])
+    R = np.stack([np.zeros(n), np.full(n, amp), np.full(n, amp), np.full(n, 0.05)])
+    got = tq.time_marginalize_bandlimited(K, R, deltaT, _helper, lnL_t=lnL)
+    rep = tq.last_report()
+    assert rep["n_nonfinite_rows"] == 1
+    assert rep["n_wrap_exposed_rows"] == 1        # the edge row ONLY
+    assert rep["n_refined_rows"] == 1             # the sharp row ONLY
+    assert not np.any(np.isnan(got))
+    # every unrefined row must be byte-equal to the historical value
+    hist = _simpson_rows(lnL, deltaT)
+    for k in (0, 1, 3):
+        assert got[k] == hist[k] or (np.isneginf(got[k]) and np.isneginf(hist[k]))
+    assert got[2] != hist[2]
+
+
+def test_a_signal_free_row_is_not_reported_as_wrap_exposed():
+    """A constant row has argmax 0.  A blanket guard would claim it and report
+    "wrap exposed", which in a production log reads as "your window is
+    mis-centred" when it means "these samples have no signal"."""
+    n, deltaT = 128, 1.0
+    lnL = np.full((1, n), 3.0)
+    got = tq.time_marginalize_bandlimited(
+        np.full((1, n), 3.0 + 0j), np.zeros((1, n)), deltaT, _helper, lnL_t=lnL)
+    rep = tq.last_report()
+    assert rep["n_wrap_exposed_rows"] == 0
+    assert rep["n_flat_rows"] == 1 and rep["n_refined_rows"] == 0
+    assert np.array_equal(got, _simpson_rows(lnL, deltaT))
+
+
+# --------------------------------------------------------------------------
+# Written because a mutation sweep showed the suite did NOT catch these.  Each
+# corresponds to a mutation that previously survived: the safety machinery was
+# present, argued for in comments, and completely unexercised.
+# --------------------------------------------------------------------------
+def test_the_factor_is_not_one_power_of_two_short_at_a_boundary():
+    """`2**ceil(log2(need))` can land one step SHORT when `need` sits a few ulp
+    above a power of two, because log2 rounds down to the integer.  Erring low
+    silently under-resolves.  A log-spaced sweep never lands there; this does,
+    by construction, at every boundary the ceiling allows.
+    """
+    dx = 1.0 / 4096
+    for k in range(0, 12):
+        need = np.nextafter(float(2 ** k), np.inf)
+        sigma = np.array([tq.UPSAMPLE_SAFETY * dx / need])
+        factor = tq._factor_per_row(sigma, dx)
+        assert dx / factor[0] <= sigma[0] / tq.UPSAMPLE_SAFETY, (k, need, factor[0])
+        assert factor[0] >= need, (k, need, factor[0])
+
+
+def test_trapezoid_returns_minus_inf_for_an_all_minus_inf_row():
+    """Unit test of `_trapezoid_log`, deliberately NOT through the integrator.
+
+    A per-row offset makes `-inf - (-inf)` reachable in principle, and NaN is
+    far worse than -inf here (NaN propagates into the sampler weights; -inf is
+    just zero weight).  Being honest about reachability: the integrator cannot
+    currently get here, because such a row has no resolvable peak, is never
+    refined, and takes the historical Simpson path.  This is defence in depth,
+    and testing it through the integrator would only re-test that routing.
+    """
+    got = tq._trapezoid_log(np.full((1, 32), -np.inf), 1.0, np.array([-np.inf]), np)
+    assert np.isneginf(got[0]), got
+    assert not np.any(np.isnan(got))
+
+
+def test_a_minus_inf_beside_the_peak_does_not_produce_a_zero_width():
+    """`distmarg_loglikelihood` returns -inf outside its table.  A -inf bin next
+    to a contributing one makes the three-point second difference -inf, hence an
+    apparent curvature of +inf and a measured width of ZERO -- "unresolvable at
+    any factor", the opposite of "flat", and it must not be silently mapped onto
+    a small factor.
+    """
+    n, dx = 201, 1.0
+    t = (np.arange(n) - n // 2) * dx
+    lnL = -0.5 * (t / (0.3 * dx)) ** 2
+    lnL[n // 2 - 2] = -np.inf          # table edge right beside the peak
+    sigma, _ = tq.peak_width_from_lnL(lnL[None, :], dx)
+    assert sigma[0] > 0 and np.isfinite(sigma[0])
+    assert sigma[0] == pytest.approx(0.3 * dx, rel=1e-6)     # the TRUE width
+    assert int(tq._factor_per_row(sigma, dx)[0]) > 1
+
+
+def test_a_zero_width_is_refused_rather_than_guessed_at():
+    """If a zero width ever does reach the factor rule it must raise.  Folding it
+    in with sigma=inf (both are non-finite after the division) would hand back a
+    small factor for an unresolvable row -- the exact failure this module exists
+    to prevent.
+    """
+    with pytest.raises(ValueError, match="non-positive measured width"):
+        tq._factor_per_row(np.array([0.0]), 1.0)
+
+
+def test_the_dense_remeasurement_recovers_an_under_derived_factor(monkeypatch):
+    """The refinement loop re-measures on the grid it actually integrated and
+    doubles until the criterion holds there too.  Force the derivation to
+    under-shoot and require the loop to notice and still land on the truth.
+    """
+    n, deltaT, amp = 128, 1.0 / 4096, 200.0
+    kap = _synthetic_kappa(n, deltaT, amp=amp)
+    t = np.arange(n) * deltaT
+    K, R = kap(t)[None, :], np.full((1, n), amp)
+    truth, ref_err = _reference_log_integral(kap, amp, t)
+
+    honest = tq.time_marginalize_bandlimited(K, R, deltaT, _helper)[0]
+    good_factor = tq.last_report()["factor"]
+    assert good_factor >= 8
+
+    real_rule = tq._factor_per_row
+    monkeypatch.setattr(
+        tq, "_factor_per_row",
+        lambda sigma, dx, xpy=np: np.minimum(real_rule(sigma, dx, xpy=xpy), 2))
+    got = tq.time_marginalize_bandlimited(K, R, deltaT, _helper)[0]
+    rep = tq.last_report()
+    assert rep["factor_initial"] == 2, rep          # the derivation under-shot
+    assert rep["factor"] >= good_factor, rep        # the re-measurement recovered
+    assert abs(got - truth) < max(10 * ref_err, 1e-9), (got, truth)
+    assert got == pytest.approx(honest, abs=1e-9)
+
+
+def test_the_log_offset_is_per_row_not_per_block():
+    """Two rows in ONE block, separated by more than ~745 nats.  A single
+    block-wide offset underflows the quieter one to exp()=0 and then log(0).
+
+    Identical kappa in both rows, so identical curvature, so the same derived
+    factor and therefore the same block -- that is the whole point.  They are
+    separated purely by the time-independent self-term, which shifts lnL by
+    0.5*rho_sq without touching the peak width.  Separating them by AMPLITUDE
+    instead lets them straddle a power-of-two factor boundary and land in
+    different blocks, which makes a block-wide offset accidentally per-row --
+    exactly how an earlier version of this test passed against a mutant.
+    """
+    n, deltaT, amp = 256, 1.0 / 4096, 400.0
+    kap = _synthetic_kappa(n, deltaT, amp=amp, seed=11)
+    t = np.arange(n) * deltaT
+    K = np.stack([kap(t), kap(t)])
+    R = np.array([np.zeros(n), np.full(n, 3000.0)])
+    got = tq.time_marginalize_bandlimited(K, R, deltaT, _helper)
+    rep = tq.last_report()
+    assert len(rep["factor_histogram"]) == 1, rep["factor_histogram"]   # one block
+    assert rep["n_refined_rows"] == 2, rep
+    assert got[0] - got[1] == pytest.approx(1500.0, abs=1e-6), got
+    assert np.all(np.isfinite(got)), got
+
+
+def test_the_report_buckets_partition_the_batch():
+    """refined + resolved + wrap-exposed + flat + nonfinite == every row.
+
+    Without this, a row can fall through a gap between the counters and be
+    invisible in a production log -- which is how "this row was skipped" gets
+    mistaken for "this row was cheap".
+    """
+    n, deltaT, amp = 128, 1.0 / 4096, 200.0
+    t = np.arange(n) * deltaT
+    rows = [
+        np.zeros(n, dtype=complex),                              # nonfinite lnL
+        _synthetic_kappa(n, deltaT, amp=amp, t0=1 * deltaT)(t),  # wrap exposed
+        _synthetic_kappa(n, deltaT, amp=amp)(t),                 # refined
+        _synthetic_kappa(n, deltaT, amp=0.05, seed=3)(t),        # already resolved
+        np.full(n, 2.0 + 0j),                                    # flat / no signal
+    ]
+    lnL = np.stack([np.full(n, -np.inf),
+                    rows[1].real - 0.5 * amp,
+                    rows[2].real - 0.5 * amp,
+                    rows[3].real - 0.5 * 0.05,
+                    np.full(n, 2.0)])
+    R = np.stack([np.zeros(n), np.full(n, amp), np.full(n, amp),
+                  np.full(n, 0.05), np.zeros(n)])
+    tq.time_marginalize_bandlimited(np.stack(rows), R, deltaT, _helper, lnL_t=lnL)
+    rep = tq.last_report()
+    buckets = ("n_refined_rows", "n_resolved_rows", "n_wrap_exposed_rows",
+               "n_flat_rows", "n_nonfinite_rows")
+    assert sum(rep[k] for k in buckets) == rep["n_rows"] == 5, \
+        {k: rep[k] for k in buckets + ("n_rows",)}
+    for k in buckets:
+        assert rep[k] == 1, (k, {b: rep[b] for b in buckets})
+
+
+# --------------------------------------------------------------------------
+# Written after the companion rift_O4d line found a wrong-answer bug in its own
+# spectrum split for ODD n.  This line's split is different and correct, and the
+# parametrised exactness test above does catch the broken form -- but only
+# because its fixture happens to populate the top bin.  These pin the class
+# directly, at the npts production actually produces and with a spectrum that
+# fills EVERY bin below Nyquist, so a fixture with a spectral gap at the top
+# cannot hide it.
+# --------------------------------------------------------------------------
+#: npts = int(2*0.075/deltaT) at srate 1024 / 2048 / 4096 / 8192 / 16384.
+#: THREE OF FIVE ARE ODD, including 16384 -- the batch-mode driver's default.
+PRODUCTION_NPTS = [153, 307, 614, 1228, 2457]
+
+
+@pytest.mark.parametrize("n", PRODUCTION_NPTS)
+@pytest.mark.parametrize("factor", [2, 4, 8])
+def test_upsample_is_exact_at_every_production_npts(n, factor):
+    """Every DFT bin strictly below Nyquist populated, odd and even n alike.
+
+    Two things hide this class and both are avoided here: the reconstruction is
+    exact at the ORIGINAL samples however the spectrum is split, so a
+    "reproduces its input" assertion cannot see it; and a fixture whose spectrum
+    stops short of Nyquist leaves the one misplaced bin empty.
+
+    Strictly below Nyquist is not a convenience: for even n a component exactly
+    at Nyquist is genuinely NOT determined by the samples (it aliases onto its
+    own conjugate), so no interpolant can recover it and there is nothing to
+    test.  Real rholm data is band-limited to fmax < srate/2, so that bin is
+    empty in practice.
+    """
+    rng = np.random.default_rng(n * 100 + factor)
+    kmax = (n - 1) // 2                     # excludes the Nyquist bin when n is even
+    ks = np.arange(1, kmax + 1)
+    a = rng.uniform(0.5, 1.5, ks.size) + 1j * rng.uniform(-1, 1, ks.size)
+    deltaT = 1.0 / 4096
+    f = ks / (n * deltaT)
+
+    def kappa_of_t(t):
+        t = np.asarray(t, dtype=float)
+        return (a[:, None] * np.exp(2j * np.pi * f[:, None] * t[None, :])).sum(axis=0)
+
+    t = np.arange(n) * deltaT
+    dense = tq.bandlimited_upsample(kappa_of_t(t)[None, :], factor)[0]
+    t_dense = np.arange(n * factor) * (deltaT / factor)
+    scale = np.abs(kappa_of_t(t)).max()
+    assert np.abs(dense - kappa_of_t(t_dense)).max() < 1e-10 * scale
+
+
+@pytest.mark.parametrize("sigma", [1e-20, 1e-30, 1e-300])
+def test_an_absurdly_sharp_width_raises_rather_than_wrapping_to_one(sigma):
+    """The ceiling is tested on the FLOAT factor, before the int64 cast.
+
+    `2**ceil(log2(need))` above 2**63 wraps to a large NEGATIVE int64 on the
+    cast, and a `maximum(.., 1)` downstream would turn that into 1 -- so
+    "unresolvable at any factor" would come back as "nothing to refine", which
+    is the same conflation as the sigma<=0 case and just as silent.
+    """
+    with pytest.raises(ValueError, match="UPSAMPLE_FACTOR_MAX"):
+        tq._factor_per_row(np.array([sigma]), 1.0 / 4096)

--- a/MonteCarloMarginalizeCode/Code/test/test_time_marginalization_wiring.py
+++ b/MonteCarloMarginalizeCode/Code/test/test_time_marginalization_wiring.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Does --time-marginalization-quadrature / time_quadrature actually DO anything?
+
+A flag that is accepted, documented, and silently inert is a known failure mode
+in this codebase, and a test that only exercises
+``time_marginalization_quadrature`` in isolation would not catch one.  These
+tests drive the SHIPPED
+``factored_likelihood.DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop``.
+
+They use synthetic rholm timeseries rather than a waveform: the likelihood only
+ever sees <h_lm(t)|d> as an array, so a band-limited synthetic exercises exactly
+the same code path in a second, with no LAL waveform generation and no data
+files.  The reference is that SAME shipped function run on a 16x finer sampling
+of the SAME continuous rholm -- so the comparison is against the production code
+at a resolution where its own Simpson rule has converged, and does not go
+through the FFT machinery under test.
+"""
+
+import numpy as np
+import pytest
+
+import RIFT.lalsimutils as lalsimutils
+import RIFT.likelihood.factored_likelihood as fl
+from RIFT.likelihood import time_marginalization_quadrature as tq
+
+import lal
+
+DETS = ["H1", "L1", "V1"]
+#: Reference comparisons use a SINGLE detector.  Not a simplification -- a
+#: necessity.  The gather is nearest-sample (ifirst = rint(tfirst/deltaT)), so
+#: refining deltaT re-quantizes EACH detector's arrival time independently, by
+#: up to deltaT/2.  Against a ~1 kHz carrier that is tens of degrees of relative
+#: phase, so the three contributions add up differently at every resolution:
+#: a "finer" run is then not a finer estimate of the same integral, it is a
+#: different integrand, and a reference built that way does not converge (it
+#: wandered by ~1 nat even at 256x oversampling).  With one detector there is no
+#: relative phase to re-quantize and the reference converges cleanly.  The
+#: nearest-sample gather is a SEPARATE known defect and is not what this change
+#: addresses.
+DETS_REF = ["H1"]
+MODES = [(2, 2), (2, -2)]
+EPOCH = 1000000014.0
+WINDOW_HALF = 0.075
+BASE_SRATE = 4096
+
+
+ENV_SIGMA = 2.0e-3   # matched-filter envelope width, seconds
+
+
+def _rholm_functions(seed=11, n_modes=5, f_max=1500.0, t_peak=0.0,
+                     dets=None):
+    """Band-limited <h_lm(t)|d> as closed-form functions of time.
+
+    A carrier (real positive mode amplitudes, so every row peaks at `t_peak`)
+    times a Gaussian envelope.  The envelope is what makes this a fair stand-in
+    for a real rholm: the integrand must DIE at the window edges, or the test
+    is dominated by where the window happens to be cut rather than by the
+    quadrature -- and the coarse and fine samplings quantise the window start
+    to their own deltaT, so their domains differ by up to one coarse sample.
+    At ENV_SIGMA=2 ms against a +-75 ms window that contribution is e^-700.
+
+    The envelope costs exact band-limitation in principle; in practice its
+    bandwidth (~1/(2 pi ENV_SIGMA) ~ 80 Hz) added to f_max stays well inside
+    the 2048 Hz Nyquist, which is the same approximation the real rholms make.
+    """
+    rng = np.random.default_rng(seed)
+    out = {}
+    out_dets = list(DETS if dets is None else dets)
+    for det in out_dets:
+        for lm in MODES:
+            f = rng.uniform(0.25 * f_max, f_max, size=n_modes)
+            a = rng.uniform(0.5, 1.5, size=n_modes)
+            a = a / a.sum()
+            ph = rng.uniform(0, 2 * np.pi)   # per-mode carrier phase
+
+            def fn(t, f=f, a=a, ph=ph):
+                t = np.asarray(t, dtype=float)
+                dt = t.ravel() - t_peak
+                z = (a[:, None] * np.exp(2j * np.pi * f[:, None]
+                                         * dt[None, :])).sum(axis=0)
+                z = z * np.exp(-0.5 * (dt / ENV_SIGMA) ** 2)
+                return (z * np.exp(1j * ph)).reshape(t.shape)
+
+            out[(det, lm)] = fn
+    out["dets"] = out_dets
+    return out
+
+
+def _build(funcs, oversample=1, amp=400.0):
+    """Pack the synthetic rholms into exactly the structures NoLoop consumes."""
+    deltaT = 1.0 / (BASE_SRATE * oversample)
+    npts_full = int(4 * WINDOW_HALF / deltaT)
+    t = (np.arange(npts_full) - npts_full // 2) * deltaT
+    lookupNK, rholm, ctU, ctV, epoch = {}, {}, {}, {}, {}
+    dets = funcs["dets"]
+    for det in dets:
+        lookupNK[det] = np.array(MODES, dtype=int)
+        rholm[det] = np.stack([amp * funcs[(det, lm)](t) for lm in MODES])
+        # cross terms: Hermitian, positive definite, time-independent
+        ctU[det] = np.eye(len(MODES), dtype=complex) * (amp / len(dets))
+        ctV[det] = np.zeros((len(MODES), len(MODES)), dtype=complex)
+        epoch[det] = EPOCH + t[0]
+    return dict(lookupNKDict=lookupNK, rholmArrayDict=rholm, ctUArrayDict=ctU,
+                ctVArrayDict=ctV, epochDict=epoch, deltaT=deltaT)
+
+
+def _P_vec(deltaT, n=3):
+    P = lalsimutils.ChooseWaveformParams()
+    P.deltaT = deltaT
+    P.tref = EPOCH
+    P.radec = True
+    P.phi = np.linspace(1.0, 1.4, n)
+    P.theta = np.linspace(0.2, 0.4, n)
+    P.psi = np.linspace(0.3, 0.9, n)
+    P.incl = np.linspace(0.8, 1.3, n)
+    P.phiref = np.linspace(0.0, 1.0, n)
+    P.dist = np.full(n, 1000.0 * 1e6 * lal.PC_SI)
+    return P
+
+
+def _tvals(deltaT):
+    n = int(2 * WINDOW_HALF / deltaT)
+    return np.linspace(-WINDOW_HALF, WINDOW_HALF, n)
+
+
+def _call(ctx, **kw):
+    P = _P_vec(ctx["deltaT"])
+    return np.atleast_1d(np.asarray(
+        fl.DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop(
+            _tvals(ctx["deltaT"]), P, ctx["lookupNKDict"],
+            ctx["rholmArrayDict"], ctx["ctUArrayDict"], ctx["ctVArrayDict"],
+            ctx["epochDict"], Lmax=2, xpy=np, **kw)))
+
+
+
+#: Oversampling for the reference: high enough that the SHIPPED Simpson rule
+#: has itself converged (single detector, it is flat from 16x on).  Every
+#: comparison below goes through `_reference`, whose second return value is its
+#: OWN convergence estimate, so no test can be tighter than the truth it is
+#: checked against.
+REF_OVERSAMPLE = 32
+
+
+def _reference(funcs, **kw):
+    """(value, convergence_estimate) from the shipped Simpson path, refined.
+
+    `funcs` must be single-detector -- see DETS_REF.
+    """
+    assert len(funcs["dets"]) == 1, "reference must be single-detector; see DETS_REF"
+    fine = _call(_build(funcs, oversample=REF_OVERSAMPLE), **kw)
+    coarser = _call(_build(funcs, oversample=REF_OVERSAMPLE // 2), **kw)
+    return fine, np.abs(fine - coarser).max()
+
+
+# --------------------------------------------------------------------------
+def test_default_reproduces_the_historical_simpson_expression_exactly():
+    """The default must be the OLD number, bit for bit.
+
+    Recomputed here straight from the returned lnL(t) timeseries, so this is an
+    independent statement of the historical formula rather than a re-run of the
+    same branch.
+    """
+    from scipy import integrate
+    simps = getattr(integrate, "simpson", None) or integrate.simps
+    ctx = _build(_rholm_functions())
+    got = _call(ctx)
+    lnLt = _call(ctx, return_lnLt=True)
+    m = lnLt.max()
+    expect = m + np.log(simps(np.exp(lnLt - m), dx=ctx["deltaT"], axis=-1))
+    assert np.array_equal(got, expect)
+
+
+def test_the_flag_is_not_inert():
+    """Flipping time_quadrature must change the returned lnL on a peaked case."""
+    ctx = _build(_rholm_functions())
+    default = _call(ctx)
+    band = _call(ctx, time_quadrature="bandlimited")
+    assert tq.last_report()["factor"] > 1
+    assert np.all(np.abs(band - default) > 0.1), (default, band)
+
+
+def test_bandlimited_matches_the_shipped_code_at_finer_sampling():
+    """Reference is the production function itself, at a resolution where its
+    own Simpson rule has converged -- not this module's FFT."""
+    funcs = _rholm_functions(dets=DETS_REF)
+    band = _call(_build(funcs), time_quadrature="bandlimited")
+    ref, conv = _reference(funcs)
+    assert np.abs(band - ref).max() < max(10 * conv, 1e-3), (band, ref, conv)
+    # and the historical path is NOT this close, on the same comparison
+    default = _call(_build(funcs))
+    assert np.abs(default - ref).max() > 0.1, (default, ref)
+
+
+def test_bandlimited_is_the_one_that_is_stable_under_grid_phase():
+    """Slide the integrand under a fixed grid: the truth cannot move."""
+    deltaT = 1.0 / BASE_SRATE
+    d_default, d_band = [], []
+    for shift in np.linspace(0.0, 2 * deltaT, 5):
+        ctx = _build(_rholm_functions(t_peak=shift))
+        d_default.append(_call(ctx))
+        d_band.append(_call(ctx, time_quadrature="bandlimited"))
+    span = lambda v: (np.max(v, axis=0) - np.min(v, axis=0)).max()
+    assert span(d_default) > 0.5, span(d_default)
+    assert span(d_band) < 1e-3, span(d_band)
+
+
+@pytest.mark.parametrize("marg", [False, True])
+def test_wiring_holds_under_phase_marginalization(marg):
+    funcs = _rholm_functions(dets=DETS_REF)
+    band = _call(_build(funcs), time_quadrature="bandlimited",
+                 phase_marginalization=marg)
+    ref, conv = _reference(funcs, phase_marginalization=marg)
+    assert np.abs(band - ref).max() < max(10 * conv, 1e-3), (band, ref, conv)
+
+
+def test_wiring_holds_for_a_nonlinear_loglikelihood_callback():
+    """Production passes distmarg_loglikelihood, not the affine default.
+
+    The callback is applied AFTER upsampling, so a nonlinear one is evaluated
+    exactly rather than approximated -- and the resolution is derived from
+    lnL(t), which already contains it.
+    """
+    nl = lambda k, r: np.log1p(np.exp(np.clip(k - 0.5 * r, -700, 700)))
+    funcs = _rholm_functions(dets=DETS_REF)
+    band = _call(_build(funcs), time_quadrature="bandlimited", loglikelihood=nl)
+    ref, conv = _reference(funcs, loglikelihood=nl)
+    assert np.abs(band - ref).max() < max(10 * conv, 1e-3), (band, ref, conv)
+
+
+def test_return_lnLt_is_unaffected_by_the_quadrature_choice():
+    """The exported lnL(t) timeseries is the COARSE one either way.
+
+    Documented, not incidental: --srate-resample-time-marginalization is a
+    separate mechanism on that path and this change deliberately leaves it
+    alone.
+    """
+    ctx = _build(_rholm_functions())
+    a = _call(ctx, return_lnLt=True)
+    b = _call(ctx, return_lnLt=True, time_quadrature="bandlimited")
+    assert np.array_equal(a, b)
+
+
+def test_an_unknown_quadrature_is_rejected_loudly():
+    ctx = _build(_rholm_functions())
+    with pytest.raises(ValueError):
+        _call(ctx, time_quadrature="trapezoid")
+
+
+def test_scope_is_the_production_path_only():
+    """NoLoopOrig and the non-NoLoop vector path keep Simpson, deliberately.
+
+    Adding an untested second copy of a numerical change is how one instance
+    becomes three different behaviours.
+    """
+    import inspect
+    for name in ("DiscreteFactoredLogLikelihoodViaArrayVectorNoLoopOrig",
+                 "DiscreteFactoredLogLikelihoodViaArrayVector",
+                 "DiscreteFactoredLogLikelihoodViaArray"):
+        sig = inspect.signature(getattr(fl, name))
+        assert "time_quadrature" not in sig.parameters, name


### PR DESCRIPTION
**Summary.** The ILE time marginalization integrates with Simpson's rule at a spacing fixed to the data sample rate, while the integrand it is integrating gets narrower as `1/rho`. Production therefore under-resolves its own integrand, worse the louder the event, and Simpson's `2h` alias makes the answer depend on where the peak happens to land between samples. This adds an **opt-in** alternative that recovers the continuous integrand from the samples already computed (one zero-padded FFT per row; `kappa(t)` is band-limited and `rho_sq` is time-independent on this path) and integrates it with the trapezoid rule at a **derived, asserted** resolution.

Measured on this line at srate 4096, rho=40, without phase marginalization: Simpson's grid-phase span is **10.3 nats** and its bias against a converged reference is **-1.96 nats**; the new path is within **3e-5**. Phase marginalization mitigates the defect substantially (the `|kappa|` envelope is broader than the carrier) — in the fullest production configuration, distance- *and* phase-marginalized, the same comparison gives a Simpson span of **0.68 nats**. At rho=5 the historical path is already fine at any setting. The error is unbounded in SNR, so it is loud events that are affected. **Defaults are unchanged** (`--time-marginalization-quadrature` defaults to `simpson`), and rows the method cannot be trusted on fall back to the historical value bit-for-bit, so enabling it cannot make any row worse than the status quo. It costs roughly **4x** the Simpson path in the likelihood call at low amplitude with phase marginalization, rising to **20-45x** at rho=80, which is stated rather than hidden — and which is a property of the *dense-grid strategy*, not of the fix: a peak-local follow-up prototyped on the companion `rift_O4d` line removes almost all of it, and this PR is the natural reference to A/B that against.

<sub>Sections below: the defect and that it reproduces here · the fix and why there is no tuning knob · the wrap guard · what is deliberately not done · what changes if you enable it (including a second, inseparable behavioural change) · cost · SNR scaling · defaults · tests · review notes.</sub>

---

## The defect

`DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop` integrates `exp(lnL(t))` over the marginalization window with **Simpson's rule at a fixed spacing `dx = deltaT = 1/srate`**. The integrand's width is not fixed. After the angle/phase reductions `exp(lnL(t))` is a near-Gaussian peak of width

```
sigma_t = 1 / (2 pi rho sigma_f)
```

with `sigma_f` the noise-weighted template frequency spread. `sigma_t` shrinks like `1/rho`, so the grid is tied to the *data sample rate* while the thing it integrates *sharpens with amplitude*. Production therefore under-resolves its own integrand, and does so worse the louder the event.

Simpson is additionally the wrong rule once under-resolved: it is `(4 T_h - T_2h)/3`, so it carries an alias of period `2h` with a minus sign, and the answer depends on **where the peak happens to fall between samples** — a quantity with no physical meaning.

## That it reproduces on `rift_O4c`

Everything below drives the **shipped** function, not a re-implementation. Setup: the `.travis`-style zero-noise injection (m1=35, m2=30 Msun, SEOBNRv4, H1L1V1, analytic iLIGO PSD, `--fmin 10 --fmax 1700`, `--data-integration-window-half 0.075`), distance tuned to the quoted network SNR.

The grid phase is swept by delaying the *injected signal* by `eps` over `[0, 2*deltaT)` via an `exp(-2 pi i f eps)` ramp on the two-sided FD data. This is the only way to move the integrand relative to the grid on this line — the gather is `ifirst = rint(tfirst/deltaT)`, so shifting `tvals` or `tref` is quantized away. The continuous integral is invariant under a rigid delay (the peak stays deep inside the +-75 ms window, where the integrand is `e^-hundreds` at the edges), so the **spread over `eps` is pure quadrature error**:

| srate | npts | sigma_t/deltaT | Simpson grid-phase span |
|------:|-----:|---------------:|------------------------:|
| 4096  | 614  | 0.104          | **10.31 nats**          |
| 8192  | 1228 | 0.207          | **2.62 nats**           |
| 16384 | 2457 | 0.409          | **0.559 nats**          |

(16 phases each. At the production `--srate 4096` setting `sigma_t/deltaT = 0.104`, i.e. the sample spacing is about **ten times wider than the peak**.)

**Which configuration this is.** The scan above, and the reference comparison below, use the
plain (non-phase-marginalized) likelihood. Phase marginalization replaces `Re kappa` with the
`|kappa|` envelope, which is materially broader — measured 31.6 us against 12.5 us at rho=80,
a factor 2.5 — so it **mitigates** this defect substantially. Both configurations are reachable
from the driver (lines 1775 and 1818), so the SNR table further down reports both, and the
phase-marginalized column is the one to read if that is how you run. Leading with the larger
number without saying which configuration produced it would overstate the case.

**A caveat I would rather state than have a reviewer find.** Those spans scale roughly as `h^2` (factors of ~4 per doubling), *not* as the exponential `2 exp(-2 pi^2 (sigma_t/2h)^2)` the alias picture gives. That is expected: at `sigma_t/h ~ 0.1-0.4` the peak is barely sampled at all and the asymptotic alias regime has not been reached. The Poisson-summation bound is quoted in this PR as the **design criterion for the fixed path** — which sits at `sigma_t/h >= 2`, deep in the exponential regime — and not as a model of the defect.


## The fix

`kappa(t)` — the data term — is **band-limited** (it is built from the rholm cross-correlation timeseries), and on this path `rho_sq` is **time-independent**. By the sampling theorem the samples the code has *already computed* determine the continuous `kappa(t)` exactly, so one zero-padded FFT per row recovers it at any spacing. We then re-apply **this caller's `loglikelihood` callback** on the dense grid and integrate with the trapezoid rule.

Three consequences worth stating explicitly:

* **No extra precompute and no new data products.** Nothing further is computed *from the data* — the information was already in the samples the code had. To be precise about where the cost then goes: the pointwise `loglikelihood` callback *is* evaluated on `factor` times as many time samples, and that, not the FFT, is the dominant cost. See the cost table.
* **Correct for every caller.** Because the callback is applied *after* upsampling, phase marginalization (`|kappa|`) and the distance-marginalization table lookup are handled exactly rather than approximated. That is also why the resolution is derived from `lnL(t)` and never from `kappa`: `lnL` is affine in `kappa` only for the default helper, so a rule built on `kappa`'s curvature would silently under-resolve exactly the phase- and distance-marginalized runs, which are the production configurations (driver lines 1775 and 1818).
* **Trapezoid, not a higher-order rule.** On a Gaussian peak the trapezoid error is `~2 exp(-2 pi^2 (sigma_t/h)^2)` by Poisson summation — spectrally accurate once `h <~ sigma_t`, and better than any polynomial rule there. Simpson's `T_2h` term is the thing being removed, not something to keep.

### There is no accuracy-versus-cost knob

This defect class exists because `n_psi=8` was settable with a docstring claiming it was ample, so the upsampling factor is **derived and then asserted**, never configured:

1. The width of the sharpest feature in each row is measured from the three-point second difference of `lnL(t)` itself. For a Gaussian `exp(lnL)`, `lnL` is exactly quadratic and the second difference of a quadratic is its second derivative **at any spacing and any offset between peak and grid** — which is precisely what lets a peak the grid cannot resolve still report its own width honestly, and so bootstrap the refinement.
2. The factor is `next_pow2(UPSAMPLE_SAFETY * deltaT / sigma_t)` with `UPSAMPLE_SAFETY = 2.0`, i.e. `h <= sigma_t/2`, leaving a residual quadrature error of ~`2e-34`. It is derived **per row**, so a handful of sharp rows do not impose their resolution on a whole 10000-row batch.
3. The width is **re-measured on the dense grid** and the factor doubled until the criterion holds there too. A coarse-grid estimate can be optimistic for a strongly non-Gaussian peak; this is what turns the derivation into an assertion.
4. `UPSAMPLE_FACTOR_MAX = 4096` **raises** rather than truncating. Silently clamping would hand back a knowingly under-resolved integral.

The factor derivation is swept exhaustively in the tests: 500,010 widths spanning the entire range the ceiling allows, zero criterion violations, all powers of two, none more than one step above what is needed. That sweep earned its keep — it caught two real defects in an earlier draft: `2**ceil(log2(need))` can land one power of two **short** when `need` sits just under a power of two (erring low, i.e. silently under-resolving), and testing the ceiling against `need` rather than against the resulting factor lets `need = 4097` through as factor 8192, above the ceiling.

### One predicate: refined, or historical

"Not refined" and "gets the historical value" are the **same** condition, deliberately:

```
refined = has a resolvable peak  AND  not wrap-exposed  AND  derived factor > 1
everything else -> the historical Simpson value, bit for bit
```

That gives a property a reviewer can check by reading one line: **a row's value differs from the historical one if and only if its integrand was under-resolved.** `last_report()['n_refined_rows']` is exactly the set of rows that moved.

Keeping the two conditions separate is how a row ends up neither refined nor historical — a signal-free row falling through to a *coarse-grid trapezoid*, which is a different rule from Simpson even though it interpolates nothing. (Both this line and the companion `rift_O4d` line had a version of that; it is now fixed on both.)

**What this does not claim.** It is not a promise that every row is at least as accurate as Simpson. The refined path carries its own ~1e-4 nat residual at the sharpest amplitudes measured, and a row where Simpson's error happens to cross zero could be marginally better under the old rule. The claim is about *which* rows change, not an accuracy ordering.

### The wrap guard

The FFT interpolant is periodic, so a peak sitting beside the wrap is not merely inaccurate but wrong in the **dangerous** direction: a spuriously high `lnL` biases the evidence up and importance-weights that sample into dominance. Measured on this line with the guard disabled, against an analytic non-periodic integrand:

| peak distance from window edge (bins) | 64 | 40 | 32 | 16 | 8 | 0 |
|---|---:|---:|---:|---:|---:|---:|
| band-limited error, guard off (nats) | -0.0000 | -0.0000 | +0.0006 | +0.017 | +0.16 | +2.19 |

The companion `rift_O4d` measurement, with a sharper peak, reached **+88.8 nats**. The magnitude depends on the peak; the sign does not.

So rows whose peak falls within `EDGE_GUARD_FRACTION = 0.125` of either edge are handed back the historical value — 0.125 of a 256-sample window is 32 bins.

**What the guard does NOT do, corrected.** An earlier draft of this PR justified the threshold with the row above ("at 32 bins the error is already 6e-4 nats") as though that were a general statement. It is not: that table is at a single amplitude, and the residual *at the boundary* scales linearly with it. Guard disabled, same fixture, sweeping amplitude:

| amp | rho ~ | at 32 bins (the boundary) | at 40 | at 64 | at 96 |
|----:|------:|--------------------------:|------:|------:|------:|
| 100   | 14  | +0.0002 | -0.0000 | +0.0000 | +0.0000 |
| 400   | 28  | +0.0006 | -0.0000 | +0.0000 | +0.0000 |
| 1600  | 57  | +0.0023 | +0.0000 | +0.0000 | +0.0000 |
| 6400  | 113 | +0.0089 | +0.0000 | +0.0000 | +0.0000 |
| 25600 | 226 | **+0.0357** | +0.0001 | +0.0000 | -0.0000 |

The decay with distance is very steep — everything at 40 bins and beyond is at or below 1e-4 at every amplitude tested — but the *level at the boundary* grows as ~1.4e-6 × amp. So **`EDGE_GUARD_FRACTION` bounds WHERE the wrap contamination can be, not HOW MUCH**, and it is a conservative heuristic rather than an error bound. Extrapolating the slope puts it at ~0.1 nats near rho ~ 375 and ~0.7 nats near rho ~ 1180; the companion `rift_O4d` line independently measured **-0.85 nats at rho ~ 1031** for a row just outside its guard, which is the same magnitude from a different fixture on a different implementation.

Practically: `n_wrap_exposed_rows` was **0 of 10000** in every production-shaped batch measured here, so no row reaches this regime at the default window — but that is an observation about the configuration, not a guarantee from the guard. Check the counter. The rigorous fix remains a wider gather. The guard only claims rows that *have* a resolvable peak — a signal-free row is constant, so its argmax is 0, and claiming it would report "the window is mis-centred" when it means "these samples have no signal".

**It interacts with `--data-integration-window-half`, and you should know how.** The band is a fraction of the window, so it scales with it. Measured, 2000 random-sky rows at rho=10:

| `--data-integration-window-half` (s) | 0.075 (default) | 0.050 | 0.030 | 0.020 | 0.010 |
|---|---:|---:|---:|---:|---:|
| rows falling back to Simpson | **0.0%** | 0.0% | 33.5% | 23.4% | 41.4% |

At the default, no row is ever claimed. Narrow the window and a large share of rows falls back — still correct, but the option stops doing anything for them. Check `n_wrap_exposed_rows` and `n_refined_rows` before concluding an enabled run actually used the new path.

The deviation cannot be estimated from the window's own samples — the periodic band-limited interpolant is uniquely determined by them, so bounding the departure needs information from *outside* the window — which is why it is bounded a priori instead. The real fix is a wider *gather*, so the wrap falls outside the integration domain; that touches the GPU kernel and its buffer-margin assumptions and is not attempted here.

*(A note for anyone extending the tests: the exactly-periodic synthetic used elsewhere in the suite — every frequency a multiple of `1/(n*deltaT)`, which is what makes the interpolation exact — **cannot exhibit wrap ringing at all**. A guard test built on it passes without demonstrating the guard is needed. The table above uses a separate, deliberately non-periodic fixture.)*

## What is deliberately NOT done

* **The integration domain is unchanged.** The dense grid spans exactly `[t_0, t_{npts-1}]`, the closed interval Simpson used. The only dense samples dropped are the `factor-1` past the last coarse sample, which are precisely the ones across the wrap. An edge *taper* was considered and rejected: it shrinks the domain, which is invisible for a sharp interior peak and a real error for a flat one — the regime where the historical path was already fine.
* **Scope is `NoLoop` only.** `DiscreteFactoredLogLikelihoodViaArrayVectorNoLoopOrig` (its own `my_simps`), `DiscreteFactoredLogLikelihoodViaArrayVector` (still called by the driver on the non-vectorized path) and `DiscreteFactoredLogLikelihoodViaArray` keep Simpson unchanged. A test asserts they have no `time_quadrature` parameter at all, so the scope limit is pinned rather than assumed.
* **The `return_lnLt=True` export path is untouched.** It returns the coarse timeseries either way; `--srate-resample-time-marginalization` is a separate mechanism on that path and is not modified. A test pins this.
* **Window mis-centring is reported, not fixed.** `last_report()['n_edge_peak_rows']` counts rows whose peak is at the very first or last sample. That is a different defect.


## What changes if you enable it

Two things change, and only the first is the quadrature. They cannot be separated: the per-row log offset is *required* by the refined path, for the reason given under (2).

**1. The quadrature error goes away.** Reference construction: keep `srate` **fixed** and move the *signal*, running R=32 independent precomputes at delays `j*deltaT/32` and interleaving them. Every dense sample is then a genuine precompute — no FFT upsampling and no spline anywhere in the reference — and because `srate` never changes, the nearest-sample `ifirst` quantization is identical across all 32 runs.

srate 4096, rho 40, four grid phases, reference `= 795.536002` at **every** phase to six decimals (the invariance the continuous integral must have, and the check that the harness itself is sound):

|                             | mean bias | worst  | grid-phase span |
|-----------------------------|----------:|-------:|----------------:|
| Simpson (shipped default)   | **-1.96 nats** | -4.17 | 4.42 |
| band-limited (this PR)      | **+0.00003**   | 0.00003 | 0.0001 |

**1b. And it goes away for the PRODUCTION callback too, not just the affine helper.** Everything above and in the SNR table uses `_factored_lnL_helper`, because it is what makes the reference constructions tractable. Production passes `distmarg_loglikelihood` — a nonlinear lookup into the distance-marginalization table — so the same interleaved-precompute comparison was repeated through that callback, rebuilt verbatim from the driver (lines 1663-1718) with a real shipped `distance_marginalization_lookup.npz`. srate 4096, rho 40:

| callback | grid phase | Simpson | band-limited | reference |
|---|---|---:|---:|---:|
| distmarg | 0.0 | **-3.205** | -2.3e-05 | 787.4163 |
| distmarg | 0.5 | **+0.297** | +1.6e-05 | 787.4163 |
| distmarg + phase marg | 0.0 | **+0.275** | +3.1e-07 | 885.5684 |
| distmarg + phase marg | 0.5 | **-0.400** | +4.4e-08 | 885.5684 |

Distance-marginalized alone: Simpson span **3.50 nats**, band-limited worst 2.3e-05 — within a few percent of the affine-helper numbers (-3.48/+0.246, span 3.72). Distance- **and** phase-marginalized, which is the fullest production configuration: Simpson span **0.675 nats**, band-limited worst 3.1e-07, and the derived factor drops from 32 to 8.

So the defect and the fix behave the same through the real nonlinear callback — that is the point of applying the callback *after* upsampling rather than approximating it — and phase marginalization is worth about a factor of five here. The reference is identical across grid phases in both configurations, as it must be.

**2. Rows far below the block maximum stop returning `-inf`.** The historical path offsets the log-sum-exp by a *single global* `lnLmax` over the whole block, so any row more than ~745 nats below the loudest underflows to `exp()=0` and then `log(0) = -inf`. The band-limited path takes the offset **per row on the dense grid**, which it must: under-resolution means the dense maximum can exceed the coarse one by thousands of nats, so reusing either the coarse or the global offset overflows to `+inf` precisely in the regime this option exists to fix. The expression is offset-invariant, so this is not a change of estimator — but it does mean rows that used to come back `-inf` now come back finite. In a random-sky batch at rho=40 that is **7753 of 10000 rows**; they carry negligible weight either way, but a downstream consumer that special-cases `-inf` should know.

Distribution of the shift on the rows where both paths are finite, `--n-chunk 10000`, srate 4096, random extrinsic points:

| rho | phase marg | rows finite in both | rescued from `-inf` | median | p95 | max |
|----:|:----------:|--------------------:|--------------------:|-------:|----:|----:|
| 10  | off | 10000 | 0    | +0.0002 | +0.165 | +0.366 |
| 10  | on  | 10000 | 0    | +0.0000 | +0.000 | +0.025 |
| 40  | off | 2247  | 7753 | +0.238  | +3.83  | +11.10 |
| 40  | on  | 3206  | 6794 | +0.068  | +0.378 | +1.48  |
| 80  | off | 20    | 9980 | +4.475  | +23.56 | +27.87 |
| 80  | on  | 39    | 9961 | +0.169  | +4.96  | +5.69  |

The shift is **positive**: the historical rule was systematically *under*-estimating the marginalized likelihood by missing the peak. It grows with SNR, as the mechanism predicts, and is several times smaller under phase marginalization (the `|kappa|` envelope is broader than the carrier).

## Cost, which is real

CPU time for the **whole likelihood call** at `--n-chunk 10000`, srate 4096 (`time.process_time`, not wall clock).

**How precise this is.** Not very, and it is worth saying so. These are shared machines; repeating the identical measurement on a second host moved the ratio by up to ~50% (e.g. 9.2x -> 6.3x at rho=10 without phase marginalization), because even CPU time responds to cache pressure from other jobs. There is an internal check available — the Simpson baseline is *rho-independent by construction*, so a run in which it jumps (one did, tripling at rho=80) is contaminated and was discarded. Read the table as **single-digit at low amplitude rising to a few tens at high amplitude**, not as three significant figures:

| rho | phase marg | ratio, host A | ratio, host B | derived factors (rows) |
|----:|:----------:|--------------:|--------------:|------------------------|
| 10 | on  | **3.6x** | 3.3x  | 4:8228 |
| 10 | off | 6.3x  | 9.2x  | 4:549, 8:9445 |
| 40 | on  | 12.2x | 10.2x | 4:21, 8:1800, 16:8178 |
| 40 | off | 31.6x | 16.6x | 4:9, 16:587, 32:9404 |
| 80 | on  | 23.7x | 19.1x | 4:19, 16:1808, 32:8173 |
| 80 | off | **44.4x** | 47.1x | 8:5, 32:608, 64:9387 |

Both hosts are shown because they disagree by up to a factor of two on the same measurement, and quoting either alone would imply a precision that is not there. Host A's Simpson baseline is flat across amplitudes (1.64-2.12 s), which is what it must be — the historical path's cost does not depend on rho — so that column is the better-conditioned one.

No extra precompute and no new data products — but the pointwise callback IS evaluated on `factor` times as many time samples, and that, not the FFT, is where the cost goes. This is the ILE inner loop. Note the phase-marginalized rows are both the cheaper and the production-relevant ones. Three honest notes:

* **Per-row factor derivation helps less than it sounds.** It works where a batch genuinely mixes widths (at rho=10 with phase marginalization, 1772 of 10000 rows derive factor 1 and cost nothing), but it does not rescue the loud case: at rho=40, 9404 of 10000 rows derive the *same* factor 32, because an extrinsic point far from the source still has a band-limited `kappa` of comparable curvature — its peak is *lower*, not *broader*. The cost there is intrinsic to resolving the integrand.
* **The dense grid is the wrong strategy, and a follow-up should replace it.** I first rejected support truncation on the grounds that it needs a bound on how far the band-limited interpolant can rise *between* coarse samples, and that a Bernstein/Nikolskii sup-norm bound does not close (it bounds `kappa`, not `exp(lnL)` after a nonlinear callback, and it degrades exactly at the peak that matters). **That conclusion was wrong, or rather it was about the wrong route.** The companion `rift_O4d` line, at RO'S's prompting, took a different one: *enumerate* every maximum of the band-limited interpolant instead of bounding the tail by inequality. Enumeration is rigorous here — `kappa` is band-limited so it has finitely many extrema and its samples determine them, and every shipped callback is monotone in `Re kappa` / `|kappa|`, so the maxima of `lnL` are the maxima of `kappa`. The mass outside a few `sigma_t` of each enumerated peak is then *bounded* rather than assumed.

  This exposes a real design flaw in what is implemented here: **two different resolution requirements are conflated.** Resolving `kappa` well enough to *enumerate* its extrema needs a small, **SNR-independent** factor, because `kappa` is band-limited at Nyquist by construction. Only resolving `exp(lnL)` is `rho`-dependent, and that only ever needs to happen over a few `sigma_t` around each peak. This PR refines the *whole window* to a peak whose width shrinks as `1/rho` — i.e. it works hardest exactly where the peak occupies least of the domain, which is why the cost table above climbs the way it does.

  Reported measurements from that prototype (on the companion line, **not** reproduced here): exact against the same analytic truth at every amplitude, and flat at ~97 evaluation points above rho~15 where the dense cost grows without bound — 200x at rho~15, ~6500x at rho~700. The naive form double-counts overlapping shallow maxima at low SNR (+1.6 nats at rho~6); merging the windows into disjoint intervals fixes it and makes it one algorithm rather than a regime switch, degenerating continuously into the dense grid as the peaks merge.

  **So read the cost table as a property of this strategy, not of the fix.** It is not a reason to reject the approach. Sequencing is deliberate: this PR is the correct-but-dense implementation, which is also the natural reference to A/B a peak-local version against. If the follow-up lands, the default still does not change.
* **The unrefined rows are genuine, checked rather than assumed.** At rho=10 with phase marginalization, 1772 of 10000 rows derive factor 1, which is where most of that row's speed comes from. A factor of 1 can also arise from a wrap-exposed row or from one whose curvature is *unmeasurable* (all `-inf`, e.g. entirely outside the distance-marginalization table) — both of which would look like cheap rows in a histogram and like a speedup in a timing table while actually having been skipped. Measured for that batch: `n_wrap_exposed_rows = 0`, `n_nonfinite_rows = 0`, `n_flat_rows = 0`, no NaN in the output — all 1772 are peaks the grid already resolves. `last_report()` carries counters for all five populations, and they partition the batch exactly, so the distinction is checkable rather than argued.


### SNR scaling

Same injection, distance tuned to each network SNR, srate 4096, two grid phases,
against the same interleaved 32-precompute reference (whose own convergence estimate
is in the last column).  `phase marg` toggles the `|kappa|` reduction; the
distance-marginalization callback is measured separately above.

| rho | phase marg | sigma_t | sigma_t/deltaT | factor | Simpson err (2 phases) | Simpson span | band-limited, worst | ref | ref conv |
|----:|:----------:|--------:|---------------:|-------:|-----------------------:|-------------:|--------------------:|----:|---------:|
| 5 | off | 199.7 us | 0.818 | 4 | +0.0111 / +0.0219 | 0.0108 | 1.7e-08 | 4.9907 | 0e+00 |
| 10 | off | 99.9 us | 0.409 | 8 | +0.1067 / +0.2513 | 0.1446 | 6.5e-07 | 42.0358 | 0e+00 |
| 20 | off | 49.9 us | 0.204 | 16 | -0.3192 / +0.6042 | 0.9234 | 5.2e-06 | 192.3188 | 3e-14 |
| 40 | off | 25.0 us | 0.102 | 32 | -3.4786 / +0.2456 | 3.7243 | 2.5e-05 | 795.5360 | 1e-13 |
| 80 | off | 12.5 us | 0.051 | 64 | -18.1658 / -3.2687 | 14.8971 | 1.0e-04 | 3210.4855 | 5e-07 |
| 5 | on | 506.3 us | 2.074 | 1 | +0.0000 / -0.0000 | 0.0000 | 2.7e-15 | 7.4894 | 9e-16 |
| 10 | on | 253.1 us | 1.037 | 2 | +0.0025 / -0.0025 | 0.0050 | 7.2e-09 | 49.2314 | 0e+00 |
| 20 | on | 126.6 us | 0.518 | 4 | +0.1192 / -0.1329 | 0.2521 | 1.3e-07 | 218.3135 | 0e+00 |
| 40 | on | 63.3 us | 0.259 | 8 | +0.2751 / -0.4005 | 0.6756 | 3.1e-07 | 896.7293 | 1e-13 |
| 80 | on | 31.6 us | 0.130 | 16 | -0.4124 / -1.1849 | 0.7725 | 1.5e-06 | 3612.4743 | 0e+00 |

**Two caveats on how to read this table, both of which I would rather state than have
a reviewer find.**

*The `sigma_t` column is not independent evidence.* It halves exactly with each doubling
of SNR (199.73 / 99.87 / 49.93 / 24.97 / 12.48 us), but that is an algebraic consequence of
how the ladder is built, not a discovery: lnL scales as 1/d^2 for a linear matched filter,
so its curvature scales as rho^2 and `sigma_t` as 1/rho by construction. What the column
*does* establish is the ABSOLUTE width -- i.e. `sigma_f` for this source, which is what
decides at which amplitude the defect starts to bite -- and that the derived factor tracks
it (4 / 8 / 16 / 32 / 64). The non-trivial content is the Simpson error columns.

*The spans here are smaller than the 16-phase scan above, and both are correct.* These rows
sample the grid phase at only TWO points, so their span is a lower bound on the envelope;
the 16-phase scan bounds it properly and gives 10.31 nats at rho=40 where this table gives
3.72. Compare like with like: the SNR *trend* is what this table is for, and the 16-phase
number is the one to quote for the size of the defect.

The Simpson error grows accordingly, and is several times smaller under phase
marginalization because the `|kappa|` envelope is broader than the carrier.

**And it costs nothing where nothing is needed.** At rho=5 with phase marginalization
`sigma_t/deltaT = 2.07`, the derived factor is **1**, no interpolation happens at all, and
Simpson's own error is 0.0000 nats. That row is the cleanest statement of the shape of this
change: it does nothing until the grid stops resolving the integrand, and then it does
exactly as much as the integrand requires. **At rho=5 the historical path is already
fine** --
which is the other half of the story: this is not a claim that every past result is wrong,
it is a claim that the error is unbounded in SNR and that loud events are where it bites.
The band-limited column stays at or below ~1e-4 nats at every amplitude -- orders of
magnitude below the Simpson error, and negligible against everything else in the
calculation. It is not always at the reference's own convergence floor (last column),
so ~1e-4 is a real residual and not a measurement limit; it is simply far below the
level at which anything downstream would notice.


## Defaults

**Nothing changes unless you ask for it.**

* `time_quadrature` defaults to `'simpson'` on the likelihood function.
* `--time-marginalization-quadrature` defaults to `'simpson'` on the driver.
* A test asserts the default output is **bit-for-bit** the historical Simpson expression, recomputed independently from the returned `lnL(t)` timeseries rather than by re-running the same branch.
* The driver validates the value **before touching any data** and prints which path is running: `Time-marginalization quadrature : bandlimited (band-limited upsampling + trapezoid; RESULT-CHANGING vs simpson)`. An opt-in flag that silently does nothing is a documented failure mode in this repo, so there is also a test that flipping it *changes the returned lnL* on a peaked case, not merely that the helper computes the right number.

## Tests

120, in three files (104 module, 10 wiring, 6 CLI), wired into `.gitlab-ci.yml` as a named-file `unit_tests` job. Note that **`.gitlab-ci.yml` on this line ran no `pytest` at all** before this PR — only the `.travis/*.sh` scripts — so everything under `MonteCarloMarginalizeCode/Code/test/` was dead weight. The job also greps the collected count, because a collection error yields zero tests and "0 tests" must not read as a pass; verified to exit non-zero on a file that fails to import.

`test_time_marginalization_quadrature.py` — the module against integrands whose value is known in closed form. No LAL, deterministic, ~9 s. Tolerances are the **reference's own convergence estimate** (the shift between one resolution and half of it), never a hardcoded constant, so no test can be tighter than the truth it checks against. Covers: FFT interpolation exactness on band-limited signals (even and odd `n`); the width estimator exact for a Gaussian at any resolution and any sub-sample offset, including 30x under-resolved; the wrap guard, on a deliberately non-periodic fixture, including the no-refinement path and the bit-for-bit fallback; overflow when the dense peak towers over the coarse one, and underflow for rows far below the block maximum; a row that is `-inf` everywhere returning `-inf` rather than **NaN**; `-inf` inside `lnL_t` not collapsing the derived factor to 1; tail noise unable to drive the factor; the exhaustive factor sweep; the report's split of the factor-1 population; input shapes; and the time-dependent `rho_sq` refusal.

`test_time_marginalization_cli.py` — the **driver**, through a subprocess. A library test cannot see the driver's option wiring at all, and the companion `rift_O4d` line found an `AttributeError` in exactly that seam (a module referenced by its submodule name rather than by the alias the import bound) which would have broken *every* invocation, flag or no flag, while all its library tests stayed green. I injected that exact bug here to check these tests are load-bearing: **3 of the 5 fail, and the `--help` one passes**, because `--help` exits before the validation line. Worth knowing, because `.travis/test-all-bin.sh` is a `--help` sweep — a syntax check wearing a smoke test's clothes. A sixth test is an `ast` ledger over the driver's call sites: every call that marginalizes must forward `time_quadrature`, and one that returns the timeseries is exempt. There is no cheap behavioural way to reach those three call sites, so the invariant is pinned structurally instead of left to a future edit.

`test_time_marginalization_wiring.py` — the shipped likelihood function, driven with synthetic band-limited rholm arrays (no waveform generation). Asserts the default is unchanged, the flag is not inert, the result matches the shipped code at 32x finer sampling, grid-phase stability, phase marginalization, a nonlinear callback, `return_lnLt` unaffected, invalid values rejected, and that `NoLoopOrig` / `ViaArrayVector` / `ViaArray` have no `time_quadrature` parameter.

**One trap worth recording for anyone extending these**, because it cost an hour and looked exactly like the fix being wrong: building a reference by *refining the sample rate* does not work on this code path. The gather is `ifirst = rint(tfirst/deltaT)`, so refining `deltaT` re-quantizes **each detector's** arrival time independently by up to `deltaT/2` — tens of degrees of relative carrier phase — and the three contributions add up differently at every resolution. A finer run is then not a finer estimate of the same integral, it is a different integrand, and the "reference" wanders (~1 nat even at 256x). Either hold the rate fixed and move the signal (the real-data reference above), or use a single detector (the wiring reference). The nearest-sample gather is a separate defect and is not addressed here.

## How this was reviewed

Beyond the tests passing, the suite was checked against **18 mutations** of the module and the driver — each disabling one piece of the safety machinery — to see which the tests actually catch. The first run found **five survivors**, all of them safety code that was present, argued for in comments, and completely unexercised:

* the off-by-one bump that stops `2**ceil(log2(need))` landing one power of two short (a log-spaced sweep never lands on the boundary; a test at `nextafter(2**k)` does);
* the `isfinite(d2)` mask on the curvature scan — and chasing that one down found a **latent bug**: a `-inf` bin from the distance-marginalization table sitting next to a contributing bin gives an apparent curvature of `+inf`, hence a measured width of *zero*, which the factor rule was silently folding in with `sigma = inf` and turning into a factor of 2. Zero width means "not resolvable at any factor" — the opposite of "flat". It now raises;
* the dense re-measurement loop (now tested by forcing the derivation to under-shoot and requiring the loop to recover);
* the per-row log offset (the old test passed against the mutant because the per-row *grouping* had accidentally put the two rows in different blocks, making a block-wide offset per-row by luck — the test now puts them in one block by construction);
* the `-inf`-row guard in the trapezoid helper, which turns out to be **unreachable** through the integrator. It is kept as defence in depth and tested as a unit, and the test says so rather than implying coverage it does not have.

All five are now caught. The re-run kills **17 of 18**; the survivor is a provably *equivalent* mutant — dropping `~exposed` from the refinement predicate changes nothing, because an exposed row already carries `sigma = inf` and so derives factor 1 either way. That was checked rather than assumed: shipped and mutant return byte-identical values and identical row classification. The sweep is a throwaway harness rather than a shipped test, so it is not in the diff; it applies each mutation with `sed`, runs the suite, and restores with `git checkout` from the commit.

**One class checked because the companion line had it.** `rift_O4d` found a wrong-answer bug in its own FFT spectrum split for **odd** `npts` (it filed the highest positive-frequency bin under a negative frequency). This matters here because `int(2*0.075*srate)` is **odd at three of the five production sample rates — 153 / 307 / 2457 at srate 1024 / 2048 / 16384 — including 16384, which is the batch-mode driver's default `--srate`.** This line's split is written differently (`n_pos = (n+1)//2`, which keeps the top positive bin) and is correct: verified to 1.6e-13 relative at every production `npts`, odd and even, at factors 2/4/8. The existing parametrised test does catch the broken form, and there is now also a test at the actual production `npts` with **every** bin below Nyquist populated — because two things hide this class, and a fixture has to avoid both: the reconstruction stays exact at the *original* samples however the spectrum is split, so a "reproduces its input" assertion cannot see it; and a spectrum that stops short of Nyquist leaves the one misplaced bin empty.

Two process notes, both learned the hard way here and both worth repeating to anyone running such a sweep:

* **Restore from the commit, never from a working-tree snapshot.** An interrupted sweep leaves the tree mutated — mine was killed mid-run twice and left `EDGE_GUARD_FRACTION = 0.0` behind once. A snapshot taken while a mutation is live becomes a poisoned baseline.
* **Check the reported buckets partition the batch.** `refined + resolved + wrap-exposed + flat + nonfinite == n_rows` is asserted by a test, because without it a row can fall through a gap between counters and be invisible in a production log — which is how "this row was skipped" gets mistaken for "this row was cheap".

## Review notes

* The interesting file is `RIFT/likelihood/time_marginalization_quadrature.py`; it imports nothing from RIFT and is backend-generic, so the same file serves this line and `rift_O4d`.
* `simps` and `lnLmax` are passed **into** the module from the caller rather than imported there, so wrap-exposed rows fall back to *this build's* Simpson — the GPU path uses `optimized_gpu_tools.simps`, and a private scipy copy would be bit-for-bit on CPU and quietly not on GPU.
* Developed alongside the equivalent `rift_O4d` change, with the API (`time_quadrature`, `--time-marginalization-quadrature`, module name and function signatures) agreed between the two so the eventual merge is textual rather than semantic. The two lines' measurements were taken by different methods — analytic closed-form integrands there, real-data multi-precompute interleaving here — and agree.
* **Coverage boundary, stated rather than implied.** The likelihood function's wiring is tested behaviourally (the flag changes the returned lnL; the default is bit-for-bit the historical expression). The *driver's* three call sites are one-line pass-throughs, visible in the diff, and are covered only by the startup validation and the reported banner — there is no end-to-end ILE run in this PR. If you want one before merging, that is a reasonable ask and I have the harness for it.
* **On comparing ratios with the `rift_O4d` PR:** the cost table here is the *whole likelihood call*. The companion line also quotes a much larger ratio for the *quadrature alone* (no gather, no einsum, no antenna response), whose denominator is a handful of array ops. Both are correct; they are not the same measurement.
* **Scope of the accuracy claims: the `nearest` gather.** Every number here is for O4c's production gather, `ifirst = rint(tfirst/deltaT)`. This line has no time-interpolation stencil in `factored_likelihood.py` at all — `--interpolate-time` exists on the driver but reaches only the legacy non-vectorized `FactoredLogLikelihoodTimeMarginalized`, never `NoLoop`. That matters going forward: PR #153 (open, onto `rift_O4c`) would add cubic interpolation to `NoLoop`, and with a stencil the gathered samples are a *filtered* `kappa`, so band-limited refinement converges to the stencil-biased integrand rather than the true one. The companion `rift_O4d` line, which has those stencils today, measures Simpson winning about half the cases under `cubic`/`sinc`. If #153 lands, these accuracy claims need re-deriving; they are not transferable.
* **A fixture note for anyone extending the tests.** A complex exponential exactly at Nyquist aliases onto its own conjugate, so the samples genuinely do not determine it and no interpolant can recover it — a test that populates that bin is asserting something unachievable, and my first version of the production-`npts` test failed at 0.20 for exactly that reason. Fill strictly below Nyquist. Physically the bin is empty anyway, since `rholm` is band-limited to `fmax < srate/2`.
* **The `~exposed` term in the refinement predicate is redundant here and load-bearing on `rift_O4d`.** This line sets `sigma_eff = inf` for exposed rows before deriving the factor, so they get factor 1 and are excluded by the `factor > 1` term regardless; the companion line leaves their sigma finite, so deleting the term there would refine exactly the +88.8-nat rows. Same behaviour, different route — flagged because a reviewer diffing the two lines will see an apparently redundant term and could "simplify" it on the wrong one.
* Not tested on GPU. The module is written against `xpy` and uses only `fft`/`where`/`max`/`sum`, all of which cupy provides, but I have not run it on a GPU and would not claim otherwise.

## Provenance

Branch `claude/o4c-tmarg-bandlimited-quadrature`, based on `upstream/rift_O4c` at `cac3b3e0` ("0.0.17.13"). All measurements taken on LIGO-CIT (`ldas-*`, `citlogin6`) with the IGWN CVMFS Python 3.11 and `OMP_NUM_THREADS=1`, driving the shipped `factored_likelihood` in this branch (`RIFT.__file__` verified to resolve into the branch checkout, not into an installed copy). Timings use `time.process_time`, since the interactive hosts were at load ~100 on 24 cores during the campaign.
