### PR TITLE
Fix ChooseFDModes J-to-L frame rotation

### DIFF
--- a/MonteCarloMarginalizeCode/Code/RIFT/lalsimutils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/lalsimutils.py
@@ -3343,16 +3343,15 @@ def hlmoft(P, Lmax=2,nr_polarization_convention=False, fixed_tapering=False, sil
        # see discussion in https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalsimulation/lib/LALSimInspiral.c
        if is_precessing and fd_L_frame and P.fref:
              alpha,beta,gamma =extract_JL_angles(P,return_inverse=True)
-             # alpha0, beta==theta_JN already identified above. Missing polarization rotation factor as well
-             # zeta_pol will not be used since it is inclination-dependent and therefore depends on extrinsic choices! Also normally calling with P.incl ==0
-             _, _, _, theta_JN, alpha0, misc_phi, zeta_pol = lalsim.SimIMRPhenomXPCalculateModelParametersFromSourceFrame(P.m1,P.m2, P.fref, P.phiref, P.incl, P.s1x, P.s1y, P.s1z, P.s2x, P.s2y, P.s2z, extra_params)
-             # Get remaining psiJ quantity (should add to extract_JL_angles)
-             thetaJN, phiJL, theta1, theta2, phi12, chi1, chi2, psiJ  = P.extract_system_frame()
-             # theta_JN is not useful, for rotations will be close to P.incl in most cases
-             alpha+= np.pi # empirically validated sign for XPHM, comparing precessing radiation to SEOBv4PHM
-#             print(alpha, beta, gamma, zeta_pol)
-#             print(alpha0, thetaJN, np.pi - phiJL,psiJ)
-             hlmsT_alt = rotate_hlm_static(hlmsT, -gamma - np.pi/2, -beta,-alpha ,extra_polarization=psiJ)  
+             # The modes must remain intrinsic: hoft_from_hlm applies P.psi when
+             # constructing the strain.  A further alpha += pi changes odd-m
+             # modes relative to even-m modes, rather than supplying a global
+             # polarization convention.  The fixed pi/2 polarization below only
+             # cancels the historical global minus sign applied above.
+             hlmsT_alt = rotate_hlm_static(
+                 hlmsT, -gamma - np.pi/2, -beta, -alpha,
+                 extra_polarization=np.pi/2,
+             )
              hlmsT = hlmsT_alt
         # phase shift ChooseFDModes
 #       for mode in hlmsT:
@@ -4025,7 +4024,7 @@ def hoft_from_hlm(hlms,P, return_complex=False, extra_phase_shift=0):
     # Create complex strain object
     hT = lal.CreateCOMPLEX16TimeSeries("hT", h22.epoch, h22.f0,
             h22.deltaT, h22.sampleUnits, h22.data.length)
-    hT.data.data*=0  # fill with zeros
+    hT.data.data[:] = 0  # fill with zeros
 
     # create for loop over elements of the series to add it
     for mode in hlms:
@@ -5789,13 +5788,13 @@ def rotate_hlm_static(hlm,alphaA,betaA,gammaA,extra_polarization=None):
                 hCatOut[(L,M)] = lal.CreateCOMPLEX16TimeSeries("Template h(t)", 
                                                  h0.epoch, h0.f0, h0.deltaT, lsu_DimensionlessUnit, 
                                                  h0.data.length)
-                hCatOut[(L,M)].data.data *=0 # initialize
+                hCatOut[(L,M)].data.data[:] = 0 # initialize
                 lal_type=True
             elif isinstance(hlm[(L,M)] , lal.Complex16FrequencySeries):
                 hCatOut[(L,M)] =  lal.CreateCOMPLEX16FrequencySeries("Template h(t)", 
                                                                      h0.epoch, h0.f0, h0.deltaF, lsu_HertzUnit ,
                                                                      h0.data.length)
-                hCatOut[(L,M)].data.data *=0 # initialize
+                hCatOut[(L,M)].data.data[:] = 0 # initialize
                 lal_type=True
             elif isinstance(hlm[(L,M)], np.ndarray):
                 hCatOut[(L,M)] = np.zeros(h0.shape)
@@ -5834,29 +5833,27 @@ def extract_JL_angles(P,return_inverse=True,phase_factor=1):
     theta_JL, phi_JL = polar_angles_in_frame(VectorToFrame(Lhat), Jhat)
     # To make review-stable, be VERY explicit : try to use lalsuite function calls, not above
     my_cos = np.dot(Lhat, Jhat)
-    theta_JL = P.incl   # this is pretty close. Good enough if we are nearly aligned
-    if my_cos < 1-1e-5:  # but if we are even slightly misaligned, use the acos of above
-        theta_JL = np.arccos( my_cos ) #P.extract_param('beta')  # this is just Jhat.Jhat
+    theta_JL = np.arccos(np.clip(my_cos, -1., 1.))
 
     # Remaining angle:
     nhat_obs = np.array([ np.sin(P.incl)*np.cos(np.pi/2*phase_factor-P.phiref), np.sin(P.incl)*np.sin(np.pi/2*phase_factor-P.phiref), np.cos(P.incl)])  # base vector
-    vecZ = np.array([0,0,1])
-    vecY = np.array([0,1,0])
-
-    # thetaJL == beta.  However, we're noit going to use this
+    # thetaJL == beta.
 #    theta_jn, _, theta_1, theta_2, phi_12, a_1, a_2 =lalsim.SimInspiralTransformPrecessingWvf2PE(
 #            P.incl, P.s1x, P.s1y, P.s1z, P.s2x, P.s2y, P.s2z, P.m1, P.m2, P.fref, P.phiref)
 
-    # rotation from J to point along L for example
-    rot = np.matmul(rotation_matrix( vecY, -theta_JL), rotation_matrix( vecZ, -phi_JL))
-
-    # Rotation around L needed to rotate viewing direction
-    nhat_rot = np.matmul(rot, nhat_obs)
-    last_angle = np.angle( nhat_rot[0]+1j*nhat_rot[1])
+    # Rotate N by Rz(-phi_JL), then Ry(-theta_JL), following Appendix C
+    # explicitly.  rotation_matrix uses a different active/passive convention,
+    # so using it here changes the final Euler angle substantially.
+    cos_phi = np.cos(phi_JL)
+    sin_phi = np.sin(phi_JL)
+    nx_rot = nhat_obs[0]*cos_phi + nhat_obs[1]*sin_phi
+    ny_rot = -nhat_obs[0]*sin_phi + nhat_obs[1]*cos_phi
+    nx_jframe = nx_rot*np.cos(theta_JL) - nhat_obs[2]*np.sin(theta_JL)
+    last_angle = np.arctan2(ny_rot, nx_jframe)
 
     # Phase conventions as in XPHM paper https://journals.aps.org/prd/abstract/10.1103/PhysRevD.103.104056
     if return_inverse:
-        # the two np.pi factors end up producing a mode sign  (-1)^m (-1)^m'  to deal with  thetaJL < 0  , so we don't have a negative angle there.
+        # The two pi factors produce (-1)^m (-1)^m' while keeping beta positive.
         return np.pi - last_angle, theta_JL, np.pi-phi_JL
     else:
         # 

--- a/MonteCarloMarginalizeCode/Code/RIFT/lalsimutils.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/lalsimutils.py
@@ -3280,7 +3280,11 @@ def hlmoft(P, Lmax=2,nr_polarization_convention=False, fixed_tapering=False, sil
        # but that is very difficult to do because modes of different 'm' and thus typical frequency generally mix
        # Note also that unless the segment length is large, this is often surprisingly few frequency bins for tapering
        if not(no_condition):
-           our_fvals = evaluate_fvals(hlmsdict[(2,2)])
+           # lal_convention=True is REQUIRED here: ChooseFDModes returns the ascending
+           # center-DC grid, and the default (RIFT reversed) convention would shift the
+           # high-pass window by one bin between (l,m) and (l,-m), breaking the
+           # conjugate-pair identity at the percent level.  See evaluate_fvals docs.
+           our_fvals = evaluate_fvals(hlmsdict[(2,2)], lal_convention=True)
            vectaper_symmetric  = np.ones(len(our_fvals))
            indx_below = np.logical_and(np.abs(our_fvals)<P.fmin, np.abs(our_fvals)>=P.fmin*fd_standoff_factor)
            vectaper_symmetric[indx_below] = 0.5 + 0.5*np.cos(np.pi* (np.abs(our_fvals[indx_below])/P.fmin - 1)/(1-fd_standoff_factor))
@@ -3305,7 +3309,15 @@ def hlmoft(P, Lmax=2,nr_polarization_convention=False, fixed_tapering=False, sil
            indx_crit = TDlen - ntaper
 
        for mode in hlmsdict:
+          npts_fd_pre_resize = hlmsdict[mode].data.length
           hlmsdict[mode] = lal.ResizeCOMPLEX16FrequencySeries(hlmsdict[mode],0, TDlen)
+          if npts_fd_pre_resize > TDlen:
+              # The resize above truncated the +fNyq bin from the two-sided grid but kept
+              # its -fNyq partner (index 0).  Zero it so the truncation commutes with the
+              # conjugate-pair (f -> -f) reflection for models with support at Nyquist.
+              # Tied to the truncation itself, NOT to no_condition: an asymmetric
+              # truncation would reintroduce (l,±m) asymmetry even on the raw path.
+              hlmsdict[mode].data.data[0] = 0
           hlmsT[mode] = DataInverseFourier(hlmsdict[mode])
           # Phase factors: see crazy conventions in https://git.ligo.org/lscsoft/lalsuite/-/blob/master/lalsimulation/lib/LALSimInspiral.c
           if True: #P.approx == lalIMRPhenomXHM or P.approx == lalIMRPhenomHM:
@@ -4906,12 +4918,25 @@ def psd_windowing_factor(window_shape, TDlen):
 def evaluate_tvals(lal_tseries):
     return float(lal_tseries.epoch) +lal_tseries.deltaT*np.arange(lal_tseries.data.length)
 
-def evaluate_fvals(lal_2sided_fseries):
+def evaluate_fvals(lal_2sided_fseries, lal_convention=False):
     r"""
-    evaluate_fvals(lal_2sided_fseries)
+    evaluate_fvals(lal_2sided_fseries, lal_convention=False)
     Associates frequencies with a 2sided lal complex array.  Compare with 'self.longweights' code
     Done by HAND in PrecessingOrbitModesOfFrequency
     Manually *reverses* convention re sign of \omega used in lal!
+
+    lal_convention=False (default): RIFT's own two-sided packing (arrays produced by
+       DataFourier/complex_hoff): even length, REVERSED, f[k] = deltaF*(npts/2 - k).
+       WARNING: for odd-length arrays this assigns f on a grid offset by deltaF/2 --
+       it is only correct for the even-length RIFT packing.
+    lal_convention=True: the packing of two-sided series returned directly by LAL
+       generators (e.g. SimInspiralChooseFDModes): ASCENDING [-fNyq, ..., 0, ..., +fNyq]
+       with DC at index npts//2 (odd length TDlen+1; even length after truncation keeps
+       DC at npts//2).  f[k] = deltaF*(k - npts//2), exact for both parities of npts.
+       Use this - not the default - on ChooseFDModes output: the default's reversal +
+       half-bin offset shifts any |f|-symmetric window by one bin between (l,m) and
+       (l,-m) modes (which live at opposite signs of f), breaking the conjugate-pair
+       identity h_{l,-m}(f) = (-1)^l conj(h_{lm}(-f)) at the percent level.
 
     Notes:
        a) XXXFrequencySeries  have an f0 and a deltaF, and *logically* they should run from f0....f0+N*df
@@ -4944,6 +4969,8 @@ def evaluate_fvals(lal_2sided_fseries):
     """
     npts = lal_2sided_fseries.data.length
     df = lal_2sided_fseries.deltaF
+    if lal_convention:
+        return df*(np.arange(npts) - npts//2)
     fvals = np.zeros(npts)
     # https://www.lsc-group.phys.uwm.edu/daswg/projects/lal/nightly/docs/html/group___time_freq_f_f_t__h.html
     # https://www.lsc-group.phys.uwm.edu/daswg/projects/lal/nightly/docs/html/_time_freq_f_f_t_8h.html

--- a/MonteCarloMarginalizeCode/Code/test/waveform/check_waveform_random.py
+++ b/MonteCarloMarginalizeCode/Code/test/waveform/check_waveform_random.py
@@ -5,6 +5,8 @@
 #   python check_waveform_random.py  --force-psi 0.1
 #   python ./check_waveform_random.py --approx SpinTaylorT4 --force-psi 0 --use-same-fref --force-aligned
 #   python check_waveform_random.py --approx SEOBNRv5EHM --force-aligned --use-eccentric --use-gwsignal --inj mdc.xml.gz --event 15
+#   python check_waveform_random.py --approximant IMRPhenomXPHM --fiducial --use-extra-fd-args --assert-overlap 0.998
+#   python check_waveform_random.py --approximant IMRPhenomXPHM --stress-q4-edge --seglen 16 --use-extra-fd-args --assert-overlap 0.995
 #
 # RESULTS
 #   - Pv2: perfect
@@ -25,6 +27,7 @@
 
 import numpy as np
 from matplotlib import pyplot as plt
+from scipy import signal
 import argparse
 import lal
 import sys
@@ -37,8 +40,11 @@ import RIFT.physics.GWSignal as rift_gws
 parser = argparse.ArgumentParser()
 parser.add_argument("--approximant",type=str,default="IMRPhenomPv2")
 parser.add_argument("--fiducial",action='store_true')
+parser.add_argument("--stress-q4-edge", action='store_true')
+parser.add_argument("--stress-near-aligned", action='store_true')
 parser.add_argument("--mtot",default=40,type=float)
 parser.add_argument("--fmin",default=20,type=float)
+parser.add_argument("--seglen", default=8, type=int)
 parser.add_argument("--use-gwsignal",action='store_true')
 parser.add_argument("--use-extra-fd-args",action='store_true')
 parser.add_argument("--use-xphm-spintaylor",action='store_true') # see https://git.ligo.org/asimov/data/-/blob/main/analyses/bilby-bbh/analysis_bilby_IMRPhenomXPHM-SpinTaylor.yaml?ref_type=heads
@@ -56,18 +62,44 @@ parser.add_argument("--use-eccentric",action='store_true')
 parser.add_argument("--inj", default=None,help="inspiral XML file containing injection information.")
 parser.add_argument("--event",type=int, default=None,help="event ID of injection XML to use.")
 parser.add_argument("--verbose",action='store_true')
+parser.add_argument("--assert-overlap", type=float, default=None,
+                    help="fail unless the mode-sum/direct flat-noise overlap, maximized over integer time and constant phase, reaches this value")
 opts=  parser.parse_args()
+
+
+def best_flat_overlap(a, b, delta_t, f_low, f_high):
+    """Flat-noise complex overlap maximized over integer time and phase."""
+    fa = np.fft.fft(a)
+    fb = np.fft.fft(b)
+    freqs = np.fft.fftfreq(len(a), delta_t)
+    keep = np.logical_and(np.abs(freqs) >= f_low, np.abs(freqs) <= f_high)
+    fa = np.where(keep, fa, 0)
+    fb = np.where(keep, fb, 0)
+    a_band = np.fft.ifft(fa)
+    b_band = np.fft.ifft(fb)
+    corr = signal.correlate(a_band, b_band, mode="full", method="fft")
+    lags = signal.correlation_lags(len(a_band), len(b_band), mode="full")
+    lag = int(lags[np.argmax(np.abs(corr))])
+    b_shift = np.zeros_like(b_band)
+    if lag >= 0:
+        b_shift[lag:] = b_band[:len(b_band)-lag]
+    else:
+        b_shift[:lag] = b_band[-lag:]
+    overlap = abs(np.vdot(a_band, b_shift))/(np.linalg.norm(a_band)*np.linalg.norm(b_shift))
+    scale = np.vdot(b_shift, a_band)/np.vdot(b_shift, b_shift)
+    return float(overlap), lag, scale
 
 P = lalsimutils.ChooseWaveformParams()
 P.ampO=-1  # need this otherwise we don't get SpinTaylor HM output
 P.phaseO = 7 # so we have less insane outputs
 P.taper = lalsimutils.lsu_TAPER_START
-if not(opts.fiducial) and not(opts.inj):
+if not(opts.fiducial or opts.stress_q4_edge or opts.stress_near_aligned) and not(opts.inj):
    print("Creating random event to use for plot comparison.")
    P.randomize()
    # move inside conditional for use inj purposes
    P.dist = RIFT.likelihood.factored_likelihood.distMpcRef*1e6*lal.PC_SI  # fiducial reference distance
    P.assign_param('mtot',opts.mtot*lal.MSUN_SI)
+
    if opts.use_eccentric:
       P.eccentricity = np.random.uniform(0.0,0.4) #for safety, for now
       P.meanPerAno = np.random.uniform(0.0,2*np.pi)
@@ -106,6 +138,17 @@ else:
    P.dist = RIFT.likelihood.factored_likelihood.distMpcRef*1e6*lal.PC_SI  # fiducial reference distance
    P.assign_param('mtot',opts.mtot*lal.MSUN_SI)
 
+   if opts.stress_q4_edge:
+      P.m1, P.m2 = 60*lal.MSUN_SI, 15*lal.MSUN_SI
+      P.incl, P.phiref, P.psi = 1.2, 1.1, 0.4
+      P.s1x, P.s1y, P.s1z = 0.75, 0.0, 0.25
+      P.s2x, P.s2y, P.s2z = -0.20, 0.25, -0.10
+   elif opts.stress_near_aligned:
+      P.m1, P.m2 = 40*lal.MSUN_SI, 20*lal.MSUN_SI
+      P.incl, P.phiref, P.psi = 1.2, 1.1, 0.4
+      P.s1x, P.s1y, P.s1z = 1e-6, 0.0, 0.4
+      P.s2x, P.s2y, P.s2z = 0.0, 0.0, -0.2
+
 if opts.force_aligned:
     P.s1x = P.s1y=P.s2x=P.s2y=0
 if not(opts.use_gwsignal):
@@ -119,8 +162,10 @@ if opts.approximant == "SEOBNRv5EHM":
    P.taper = lalsimutils.lsu_TAPER_NONE
    
 P.deltaT=1./4096
-P.deltaF = 1./8
+P.deltaF = 1./opts.seglen
 P.fref = 22
+if opts.stress_q4_edge:
+    P.fref = 30
 P.fmin=opts.fmin
 if opts.use_same_fref:
     P.fref = P.fmin
@@ -132,11 +177,10 @@ if opts.force_zero_inclination:
 P.print_params()
 
 # hoft via hlm, using exactly the function call we use in production
-extra_args ={}
 extra_waveform_args ={}
 extra_waveform_args['fd_centering_factor']= 0.9
 if opts.use_extra_fd_args:
-    extra_args['fd_L_frame'] = True
+    extra_waveform_args['fd_L_frame'] = True
 if opts.use_xphm_spintaylor:
     extra_waveform_args['FinalSpinMod'] =2
     extra_waveform_args['PhenomXPHMReleaseVersion'] = 122022
@@ -144,7 +188,7 @@ if opts.use_xphm_spintaylor:
 
 
 P_copy = P.manual_copy() # beware, call may change P!
-hlmF_1, _= factored_likelihood.internal_hlm_generator(P_copy, opts.Lmax, use_gwsignal=opts.use_gwsignal, use_gwsignal_approx=opts.approximant,ROM_group=opts.rom_group,ROM_param=opts.rom_param, extra_waveform_kwargs=extra_waveform_args, **extra_args)
+hlmF_1, _= factored_likelihood.internal_hlm_generator(P_copy, opts.Lmax, use_gwsignal=opts.use_gwsignal, use_gwsignal_approx=opts.approximant,ROM_group=opts.rom_group,ROM_param=opts.rom_param, extra_waveform_kwargs=extra_waveform_args)
 hlmT_1  = {}
 for mode in hlmF_1:
     hlmT_1[mode] = lalsimutils.DataInverseFourier(hlmF_1[mode])
@@ -182,6 +226,36 @@ else:
   #hTc_2 = 
 if opts.verbose:
   print('net2 ', np.max(np.abs(hTc_2.data.data)))
+
+if opts.assert_overlap is not None:
+    overlap, lag, scale = best_flat_overlap(
+        np.asarray(hTc_1.data.data), np.asarray(hTc_2.data.data),
+        float(hTc_1.deltaT), P.fmin, min(1024., 0.5/P.deltaT),
+    )
+    print("Mode-sum/direct overlap", overlap, "at lag", lag, "samples")
+    if not np.isfinite(overlap) or overlap < opts.assert_overlap:
+        raise SystemExit("FAIL: overlap {} is below {}".format(overlap, opts.assert_overlap))
+    print("Best aligned complex scale", scale)
+    if not np.isfinite(scale) or abs(np.angle(scale)) > 0.05 or not 0.8 < abs(scale) < 1.2:
+        raise SystemExit("FAIL: mode-sum/direct phase or amplitude convention is inconsistent")
+
+    # fd_L_frame modes are intrinsic.  Polarization is applied only when the
+    # modes are summed into strain, so changing psi must not change any mode.
+    P_psi = P.manual_copy()
+    P_psi.psi += 0.37
+    hlmF_psi, _ = factored_likelihood.internal_hlm_generator(
+        P_psi, opts.Lmax, use_gwsignal=opts.use_gwsignal,
+        use_gwsignal_approx=opts.approximant, ROM_group=opts.rom_group,
+        ROM_param=opts.rom_param, extra_waveform_kwargs=extra_waveform_args,
+    )
+    relative_mode_difference = max(
+        np.linalg.norm(hlmF_1[mode].data.data - hlmF_psi[mode].data.data)
+        / max(np.linalg.norm(hlmF_1[mode].data.data), np.finfo(float).tiny)
+        for mode in hlmF_1
+    )
+    print("Maximum relative mode change under psi shift", relative_mode_difference)
+    if relative_mode_difference > 1e-12:
+        raise SystemExit("FAIL: intrinsic modes depend on polarization angle")
 
 # now confirm complex_hoft dependence on psi is as desired
 #    NOT THE SAME PSI DEPENDENCE AS WE ASSUME ELSEWHERE


### PR DESCRIPTION
## Summary

Fix the `SimInspiralChooseFDModes` J-frame to L-frame conversion used by
`fd_L_frame`, and make the existing waveform comparison exercise and assert
the production path.

This branch is based directly on `oshaughn:rift_O4c`.  It also includes the
requested conditioning fix from #163 (`06764daf`) because the frame test must
run on the corrected symmetric two-sided FD grid.

## Diagnosis and fix

- `extract_JL_angles` used a generic rotation matrix with an incompatible
  active/passive convention.  It now implements the Appendix-C/Dingo sequence
  explicitly: `Rz(-phi_JL)` followed by `Ry(-beta)`.
- The old `alpha += pi` changes odd-m modes relative to even-m modes.  Remove it.
- `psiJ` is extrinsic and must not be baked into returned L-frame modes;
  `hoft_from_hlm` applies `P.psi` when constructing strain.  Replace it with a
  fixed `pi/2` factor that only cancels the preceding historical global minus.
- Always use clipped `acos(Jhat.Lhat)` for beta, including nearly aligned but
  nonzero-transverse-spin systems.
- Explicitly zero new LAL arrays instead of multiplying uninitialized storage by
  zero, which can preserve allocator NaNs.

The shared convention also applies to XPNR and XO4a; both have explicit smoke
test results below.

## Validation

Raw FD mode-sum comparisons against `SimInspiralChooseFDWaveform`:

- fiducial precessing XPHM: overlap `0.9999992`
- q=4 edge-on XPHM: overlap `0.9999987`
- old rotation for the same cases: `0.0666` and `0.0394`

Conditioned production-path checks use linear, zero-filled time alignment (not
circular roll), assert the complex phase/amplitude convention, and verify that
changing `psi` leaves every intrinsic mode unchanged:

- fiducial, 8 s: overlap `0.999175`, scale `1.000571-0.000682i`, psi delta `0`
- q=4 edge-on, 16 s: overlap `0.996263`, scale `1.001647-0.002827i`, psi delta `0`
- near-aligned transverse spin `1e-6`, 16 s: overlap `0.997735`, scale
  `1.000425-0.001885i`, psi delta `0` (old beta logic: overlap `0.97456`)
- XO4a fiducial: overlap `0.999887`
- XPNR fiducial: overlap `0.999872`

The lower conditioned stress-case overlaps reflect the existing FD
windowing/centering path; the strict raw-FD checks isolate the frame convention.
The stress runs use 16 s deliberately to reduce higher-mode wraparound.

The sign-sensitive regression was mutation-tested: removing the fixed `pi/2`
leaves the phase-maximized overlap unchanged but produces scale approximately
`-1` and fails the new complex-convention assertion.

## Adversarial review

An internal adversarial pass challenged near-aligned behavior, global sign,
circular wraparound, stress coverage, shared approximants, and uninitialized LAL
buffers.  The resulting findings were fixed and the closure review reported no
remaining blocking or high-severity findings.
