### PR TITLE
Ecc/meanPerAno when converting grid with inference2ile

### DIFF
--- a/MonteCarloMarginalizeCode/Code/bin/convert_output_format_inference2ile
+++ b/MonteCarloMarginalizeCode/Code/bin/convert_output_format_inference2ile
@@ -166,6 +166,9 @@ for indx in np.arange(opts.target_size):
             lambda1, lambda2 = lalsimutils.tidal_lambda_from_tilde(m1,m2,lambdat_here, dlambdat_here)
             P.lambda1 = lambda1
             P.lambda2 =lambda2
+    if "eccentricity" in samples_in.dtype.names:
+            P.eccentricity = samples_in["eccentricity"][fac_reduce*indx]
+            P.meanPerAno = samples_in["meanPerAno"][fac_reduce*indx]
 
     # Add extrinsic parameters...NEED TO DOUBLE CHECK
     if opts.use_extrinsic:  # note the Euler angles are already set


### PR DESCRIPTION
Added options to include ecc/meanPerAno when converting from ascii to xml for grids/samples. Previously, would just zero out eccentricity and meanPerAno even if samples included them.