### PR TITLE
factored_likelihood: offset the vectorized time integral per row, not per batch (fixes -inf / mcsamplerAV collapse above rho ~ 40; issue #232)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ default:
 
 stages:
   - system tests
-  - unit tests # TODO: write some
+  - unit tests
   - docs
 #  - docker image
 #  - deploy
@@ -46,6 +46,14 @@ import_check:
   stage: system tests
   script:
     - python .travis/test-all-mod.py
+
+# Named unit tests.  CI runs FILES BY NAME here: a test file that is not listed
+# below never runs.  Add new regression tests to this list in the same commit
+# that adds the file.
+unit_tests:
+  stage: unit tests
+  script:
+    - python -m pytest -q MonteCarloMarginalizeCode/Code/test/test_time_marginalization_perrow_offset.py
 
 test_run:
   stage: system tests

--- a/MonteCarloMarginalizeCode/Code/RIFT/likelihood/factored_likelihood.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/likelihood/factored_likelihood.py
@@ -2030,7 +2030,14 @@ def  DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop(tvals, P_vec, lookupNKDic
         lnL_t = loglikelihood(kappa_sq.real, rho_sq)
 
     # Take exponential of the log likelihood in-place.
-    lnLmax  = xpy.max(lnL_t)
+    # The offset must be PER EXTRINSIC SAMPLE (axis=-1 is time).  A batch-wide
+    # offset underflows exp() to zero across the whole time axis for any row
+    # peaking more than ~745 nats below the loudest row in the batch, returning
+    # -inf where the likelihood is finite (onset near max lnL ~ 745, rho ~ 40).
+    # keepdims=True is load-bearing: a (npts_extrinsic,) offset would broadcast
+    # along the time axis instead.  See issue oshaughnessy-junior/
+    # research-projects-RIT#232.
+    lnLmax  = xpy.max(lnL_t, axis=-1, keepdims=True)
     if return_lnLt:
       return lnL_t  #- lnLmax    # we want the verbatim lnL_t values, no shift
     L_t = xpy.exp(lnL_t - lnLmax, out=lnL_t)
@@ -2038,7 +2045,7 @@ def  DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop(tvals, P_vec, lookupNKDic
     L = simps(L_t, dx=deltaT, axis=-1)
 
     # Compute log likelihood in-place.
-    lnL = lnLmax + xpy.log(L, out=L)
+    lnL = lnLmax[...,0] + xpy.log(L, out=L)
 
     return lnL
 

--- a/MonteCarloMarginalizeCode/Code/test/test_time_marginalization_perrow_offset.py
+++ b/MonteCarloMarginalizeCode/Code/test/test_time_marginalization_perrow_offset.py
@@ -1,0 +1,229 @@
+"""
+Regression test for the per-row offset in the vectorized time-marginalized
+likelihood (``DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop``).
+
+The function reduces an array ``lnL_t`` of shape ``(npts_extrinsic, npts_time)``
+over its time axis.  The offset used to stabilize ``exp()`` must be taken
+*per extrinsic sample*.  If the whole-array (batch) maximum is used instead,
+any row whose own peak sits more than ~745 nats below the loudest row in the
+batch underflows to zero across the entire time axis and the function returns
+``-inf`` where the likelihood is finite.  See
+https://github.com/oshaughnessy-junior/research-projects-RIT/issues/232 .
+
+The invariant tested here is *batch independence*: the marginalized ``lnL`` of
+an extrinsic sample must not depend on which other samples happen to share its
+batch.  It is checked by comparing a batch evaluation against evaluating the
+same samples one at a time through the same function (a batch of one is
+trivially offset by its own maximum, so the singleton path is correct even on
+the unpatched code).  This is a property of the shipped function, not of a
+re-implementation of its kernel.
+
+The tests deliberately use ``npts_extrinsic != npts_time`` so that an offset
+array of the wrong shape (``axis=-1`` without ``keepdims=True``, i.e. shape
+``(npts_extrinsic,)``) raises rather than broadcasting silently along the
+time axis.
+"""
+
+import numpy as np
+
+# Hard imports, not importorskip: lalsuite is a declared requirement, and a
+# silently skipped regression test is not a regression test.
+import lal
+
+import RIFT.lalsimutils as lalsimutils
+from RIFT.likelihood import factored_likelihood
+
+DET = "H1"
+LMS = np.array([[2, 2], [2, -2]], dtype=int)
+NPTS_TIME = 65        # odd, so Simpson needs no even-sample special case
+NPTS_FULL = 1024
+DELTA_T = 1.0 / 4096
+IFIRST_NOMINAL = 384  # keeps [ifirst, ifirst+npts) inside the buffer for any sky location
+TREF = 1000000000.0
+
+
+def _rholms_array():
+    """A smooth, band-limited complex 'bump' timeseries for each (l,m) mode."""
+    n = np.arange(NPTS_FULL)
+    center = IFIRST_NOMINAL + NPTS_TIME // 2
+    width = 12.0
+    envelope = np.exp(-0.5 * ((n - center) / width) ** 2)
+    phase = 2 * np.pi * n / 97.0
+    out = np.empty((len(LMS), NPTS_FULL), dtype=np.complex128)
+    out[0] = envelope * np.exp(1j * phase)
+    out[1] = envelope * np.exp(-1j * phase) * 0.8
+    return out
+
+
+def _make_inputs(n_extrinsic, dist_mpc, cross_terms_scale=0.0):
+    """Build the argument set for the vectorized likelihood.
+
+    ``cross_terms_scale = 0`` zeroes the U and V cross terms, hence rho^2, so
+    that lnL(t) is exactly linear in 1/distance.  That is what lets a test
+    place rows a chosen number of nats apart.
+    """
+    rng = np.random.default_rng(20260902)
+
+    P = lalsimutils.ChooseWaveformParams()
+    P.deltaT = DELTA_T
+    P.tref = TREF
+    P.phi = rng.uniform(0.0, 2 * np.pi, n_extrinsic)          # RA
+    P.theta = np.arcsin(rng.uniform(-1.0, 1.0, n_extrinsic))  # DEC
+    P.phiref = rng.uniform(0.0, 2 * np.pi, n_extrinsic)
+    P.incl = np.arccos(rng.uniform(-1.0, 1.0, n_extrinsic))
+    P.psi = rng.uniform(0.0, np.pi, n_extrinsic)
+    P.dist = np.asarray(dist_mpc, dtype=np.float64) * 1e6 * lal.PC_SI
+
+    n_lms = len(LMS)
+    U = np.zeros((n_lms, n_lms), dtype=np.complex128)
+    V = np.zeros((n_lms, n_lms), dtype=np.complex128)
+    if cross_terms_scale:
+        U[:] = cross_terms_scale * np.eye(n_lms)
+        V[:] = cross_terms_scale * 0.1 * np.eye(n_lms)
+
+    tvals = np.arange(NPTS_TIME) * DELTA_T
+    epoch = TREF - IFIRST_NOMINAL * DELTA_T
+
+    return dict(
+        tvals=tvals,
+        P_vec=P,
+        lookupNKDict={DET: LMS},
+        rholmsArrayDict={DET: _rholms_array()},
+        ctUArrayDict={DET: U},
+        ctVArrayDict={DET: V},
+        epochDict={DET: epoch},
+    )
+
+
+def _lnL(kwargs, **extra):
+    return factored_likelihood.DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop(
+        kwargs["tvals"], kwargs["P_vec"], kwargs["lookupNKDict"],
+        kwargs["rholmsArrayDict"], kwargs["ctUArrayDict"], kwargs["ctVArrayDict"],
+        kwargs["epochDict"], Lmax=2, xpy=np, **extra
+    )
+
+
+def _select_row(kwargs, i):
+    """A one-sample copy of ``kwargs``, sharing everything but the extrinsic row."""
+    P = kwargs["P_vec"]
+    P1 = lalsimutils.ChooseWaveformParams()
+    P1.deltaT = P.deltaT
+    P1.tref = P.tref
+    for name in ("phi", "theta", "phiref", "incl", "psi", "dist"):
+        setattr(P1, name, np.atleast_1d(getattr(P, name))[i:i + 1].copy())
+    out = dict(kwargs)
+    out["P_vec"] = P1
+    # rholms are consumed in place by the exp(..., out=...) call: hand out fresh copies
+    out["rholmsArrayDict"] = {k: v.copy() for k, v in kwargs["rholmsArrayDict"].items()}
+    return out
+
+
+def _singleton_reference(dist_mpc, cross_terms_scale=0.0):
+    """Evaluate each extrinsic sample in its own batch of one."""
+    n = len(dist_mpc)
+    ref = np.empty(n, dtype=np.float64)
+    for i in range(n):
+        kw = _make_inputs(n, dist_mpc, cross_terms_scale)
+        ref[i] = np.asarray(_lnL(_select_row(kw, i)))[0]
+    return ref
+
+
+def _distances_for_peaks(target_peaks):
+    """Distances placing each sample's own peak lnL at the requested value.
+
+    lnL(t) is linear in distMpcRef/dist when the cross terms are zero, so one
+    unit-distance evaluation calibrates the whole ladder.
+    """
+    n = len(target_peaks)
+    unit = np.full(n, float(factored_likelihood.distMpcRef))
+    kw = _make_inputs(n, unit)
+    lnL_t = np.asarray(_lnL(kw, return_lnLt=True))
+    peak_unit = lnL_t.max(axis=-1)
+    assert np.all(peak_unit > 0), "test fixture degenerate: unit-distance peaks not positive"
+    return unit * peak_unit / np.asarray(target_peaks, dtype=np.float64)
+
+
+def test_loud_batch_does_not_underflow_quiet_rows():
+    """A batch spanning far more than the 745-nat float64 exp() budget.
+
+    Row 0 peaks near 1500 nats (rho ~ 55); the rest sit near the prior bulk.
+    With a batch-wide offset every row but the loudest underflows to -inf.
+    """
+    targets = np.array([1500.0, 900.0, 400.0, 5.0, 0.5])
+    dist = _distances_for_peaks(targets)
+
+    kw = _make_inputs(len(targets), dist)
+    lnL = np.asarray(_lnL(kw))
+
+    assert np.all(np.isfinite(lnL)), (
+        "batch-max offset underflowed finite rows: lnL = {}".format(lnL))
+
+    ref = _singleton_reference(dist)
+    assert np.allclose(lnL, ref, rtol=0, atol=1e-6), (
+        "batch result differs from one-at-a-time evaluation:\n"
+        "  batch     = {}\n  singleton = {}\n  delta     = {}".format(
+            lnL, ref, lnL - ref))
+
+
+def test_well_resolved_batch_matches_singleton():
+    """A batch where nothing underflows: the result must be unchanged.
+
+    Per-row and batch offsets are not bit-identical -- they are different
+    floating-point reductions.  Measured on this fixture (igwn python 3.11,
+    numpy float64), batch-max vs per-row offsets agree to 1.8e-15 nats at
+    peaks of 12..1 nats, 3.6e-15 nats at 40..2 nats, and 7.1e-14 nats at
+    700..100 nats: ~1 ulp relative in every case.  The per-row batch result
+    is exactly equal to the one-at-a-time result, because it is the same
+    arithmetic on the same row, so the tolerance here is tight.
+    """
+    targets = np.array([12.0, 9.0, 6.0, 3.0, 1.0])
+    dist = _distances_for_peaks(targets)
+
+    kw = _make_inputs(len(targets), dist)
+    lnL = np.asarray(_lnL(kw))
+    ref = _singleton_reference(dist)
+
+    assert np.all(np.isfinite(lnL))
+    assert np.max(np.abs(lnL - ref)) < 1e-12, (
+        "well-resolved batch/singleton disagreement {} exceeds rounding scale".format(
+            np.max(np.abs(lnL - ref))))
+
+
+def test_matches_singleton_with_nonzero_cross_terms():
+    """Same invariant with rho^2 present, i.e. the full physical lnL."""
+    dist = np.array([120.0, 200.0, 350.0, 600.0, 1000.0])
+
+    kw = _make_inputs(len(dist), dist, cross_terms_scale=3.0)
+    lnL = np.asarray(_lnL(kw))
+    ref = _singleton_reference(dist, cross_terms_scale=3.0)
+
+    assert np.all(np.isfinite(lnL))
+    assert np.allclose(lnL, ref, rtol=0, atol=1e-6), (
+        "batch = {}\nsingleton = {}".format(lnL, ref))
+
+
+def test_single_sample_batch_is_finite():
+    """The degenerate (1, npts_time) case: the offset must still be per row."""
+    dist = _distances_for_peaks(np.array([1500.0]))
+    kw = _make_inputs(1, dist)
+    lnL = np.asarray(_lnL(kw))
+    assert lnL.shape == (1,)
+    assert np.all(np.isfinite(lnL))
+
+
+def test_return_lnLt_is_unshifted():
+    """The ``return_lnLt`` early return must hand back lnL(t) verbatim.
+
+    Guards against 'fixing' the offset by moving the subtraction above the
+    early return, which would silently shift every exported lnL(t).
+    """
+    targets = np.array([1500.0, 5.0, 0.5])
+    dist = _distances_for_peaks(targets)
+
+    kw = _make_inputs(len(targets), dist)
+    lnL_t = np.asarray(_lnL(kw, return_lnLt=True))
+
+    assert lnL_t.shape == (len(targets), NPTS_TIME)
+    assert np.allclose(lnL_t.max(axis=-1), targets, rtol=1e-8), (
+        "return_lnLt no longer returns unshifted lnL(t): peaks = {}".format(
+            lnL_t.max(axis=-1)))


### PR DESCRIPTION
Fixes the confirmed defect in https://github.com/oshaughnessy-junior/research-projects-RIT/issues/232, on `rift_O4c`.

Submitted at R. O'Shaughnessy's explicit direction. The issue deliberately stopped at diagnosis; this is the patch he asked for.

## Mechanism

`DiscreteFactoredLogLikelihoodViaArrayVectorNoLoop` reduces `lnL_t` of shape `(npts_extrinsic, npts_time)` over its time axis. The offset used to stabilize `exp()` was the **whole-array** maximum, so every extrinsic sample was shifted by the **batch** peak rather than its own:

```python
lnLmax  = xpy.max(lnL_t)          # no axis
L_t     = xpy.exp(lnL_t - lnLmax, out=lnL_t)
L       = simps(L_t, dx=deltaT, axis=-1)
lnL     = lnLmax + xpy.log(L, out=L)
```

Any row whose own peak sits more than ~745 nats below the loudest row in the batch has `exp()` underflow to 0 across the entire time axis, so `L = 0` and `log(L) = -inf` at a point where the likelihood is perfectly finite. A typical prior draw sits near `lnL ~ 0` and the peak near `rho^2/2`, so the defect switches on once `max lnL > ~745` (`rho ~ 40`) and then hits the **bulk** of the prior, not a tail. `mcsamplerAV` collapses.

The path is selected by `opts.gpu`, and `--force-xpy` keeps `opts.gpu` true with no cupy, so **this is device-independent** — cupy is not implicated, and it is not the CPU/GPU Simpson divergence (#204, bounded to `[ln(2/3), ln(4/3)]`, which cannot produce `-inf`).

## The fix

```diff
-    lnLmax  = xpy.max(lnL_t)
+    lnLmax  = xpy.max(lnL_t, axis=-1, keepdims=True)
     if return_lnLt:
       return lnL_t  #- lnLmax    # we want the verbatim lnL_t values, no shift
     L_t = xpy.exp(lnL_t - lnLmax, out=lnL_t)
     L = simps(L_t, dx=deltaT, axis=-1)
-    lnL = lnLmax + xpy.log(L, out=L)
+    lnL = lnLmax[...,0] + xpy.log(L, out=L)
```

The `return_lnLt` early return is untouched: it still hands back `lnL_t` verbatim.

### Shape trap

**`axis=-1` alone is not enough.** Without `keepdims=True` the offset is `(npts_extrinsic,)` and `lnL_t - lnLmax` broadcasts along the **time** axis. When `npts_extrinsic == npts_time` that is silently wrong with no exception. Either `keepdims=True` with `lnLmax[...,0]` on the add-back (chosen here), or `keepdims=False` with `lnLmax[...,None]` in the subtraction.

The test file uses `npts_extrinsic = 5`, `npts_time = 65` precisely so this variant raises rather than broadcasting. Mutation-checked: rewriting the patch as bare `axis=-1` turns **three** of the five tests red.

## Regression test, and it was seen to fail

`MonteCarloMarginalizeCode/Code/test/test_time_marginalization_perrow_offset.py`, wired into `.gitlab-ci.yml` in the same commit (a new `unit_tests` job filling the pre-existing, empty `unit tests` stage — CI here runs files by name, so an unlisted test never runs; `.github/workflows/` does not exist on this branch).

The invariant tested is **batch independence**: the marginalized `lnL` of an extrinsic sample must not depend on which other samples share its batch. It is checked by comparing a batch evaluation against evaluating the same samples one at a time *through the same shipped function* — a batch of one is trivially offset by its own maximum, so the singleton path is correct even on unpatched code. Nothing about the kernel is re-implemented in the test.

On the unpatched file (`git show HEAD~1`):

```
FAILED test_time_marginalization_perrow_offset.py::test_loud_batch_does_not_underflow_quiet_rows
E   AssertionError: batch-max offset underflowed finite rows:
E     lnL = [1491.27766487  891.27676873  -inf  -inf  -inf]
...
factored_likelihood.py:2041: RuntimeWarning: divide by zero encountered in log
1 failed, 4 passed
```

With the patch: `5 passed`.

The five tests: the loud batch above (peaks 1500/900/400/5/0.5 nats); a well-resolved batch; a batch with non-zero `U`/`V` cross terms, i.e. the full physical `lnL` with `rho^2` present; the degenerate `(1, npts_time)` batch; and a guard that `return_lnLt` still returns `lnL(t)` unshifted (so nobody "fixes" this by moving the subtraction above the early return).

## Measured effect — this is NOT a no-op

**This moves production numbers on the `--gpu` path for loud events. That is the point.** Reviewers should expect delivered results above `rho ~ 40` to change.

Real data, from the issue (S250114ax H1/L1, SEOBNRv5PHM lmax=4, srate 4096, `rho ~ 82`, AV, `--n-max 4e6`, seeds 3001/3002/3003, one container, one host, backend proven in-process):

| arm | chi-square ESS | Pareto k-hat | reported `lnL` |
|---|---:|---:|---|
| `--gpu`, as shipped | 1.0 / 1.0 / 1.0 | 21.8 / 16.2 / 23.6 | 3365.57 / 3346.74 / 3381.48 |
| `--gpu`, per-row offset | **146.6 / 152.9 / 102.5** | **0.44 / 0.34 / 0.51** | 3370.95 / 3371.32 / 3370.83 |
| CPU reference (no `--gpu`) | 102.6 / 104.0 / 123.0 | 0.51 / 0.64 / 0.47 | 3371.48 / 3370.71 / 3371.11 |

The shipped arm scatters over **34.7 nats** across three seeds while reporting `sigma = 1.03`. With the per-row offset it agrees with the CPU reference to 0.07 nats, inside the 0.26–0.38 nat replicate spread.

### Where nothing underflows — no bit-identity claimed

Per-row and batch offsets are different floating-point reductions, so they are **not** guaranteed bit-identical even where nothing underflows. Measured directly on the test fixture (igwn python 3.11, numpy float64), old vs new `lnL`:

| fixture, per-row peak `lnL` | max abs difference | max relative |
|---|---:|---:|
| 12, 9, 6, 3, 1 nats | 1.8e-15 nats | 8.9e-16 |
| 40, 30, 20, 10, 2 nats | 3.6e-15 nats | 8.9e-16 |
| 700, 600, 400, 200, 100 nats | 7.1e-14 nats | 7.8e-16 |
| 1500, 900, 400, 5, 0.5 nats | `inf` (three rows go `-inf` unpatched) | — |

So: **agrees to ~1 ulp (<= 1e-13 nats) below the underflow budget**, not "unchanged".

End-to-end confirmation on the shipped CI system test's own workload (`.travis/test-run.sh` → `ILE-GPU-Paper/demos`, zero-noise SEOBNRv4 35+30, H1/L1, `--vectorized --gpu --force-xpy`, `--n-max 50000`, `--seed 4321`, 4 intrinsic points, max `lnL ~ 58–72` nats, i.e. well below onset): patched and unpatched runs both exit 0, and the reported `lnL` column of `*_.dat` is identical in every printed digit for all four events. Only the `neff` / `int_var` diagnostics differ, at 1e-15 / 1e-16 relative. (A coincidence of this well-resolved case — see the table above; do not read it as a bit-identity guarantee.)

## Unexercised siblings — deliberately NOT changed

Same construction is not the same diagnosis. Neither of these was reproduced, so neither is touched here:

- `factored_likelihood.py:1788`, in `DiscreteFactoredLogLikelihoodViaArrayVectorNoLoopOrig`: `lnLmax = np.max(lnL_t_accum)` with `lnL_t_accum` of shape `(npts_extrinsic, npts)` — same shape, same exposure, **no measurement here**.
- The in-loop calmarg site the issue lists at `factored_likelihood.py:3132` on later branches (`m_c = xpy.max(lnL_t_c)` feeding a global `running_max`) **does not exist on `rift_O4c`**; it may in any case be correct by design.

The correct idiom `xpy.max(..., axis=-1, keepdims=True)` is already used at several sites elsewhere in the tree.

A sibling PR carries the identical fix onto `rift_O4d`.

## Open questions for you, not settled by this PR

1. Whether any delivered `--gpu` result above `rho ~ 40` needs re-running. The issue identifies exactly two runs in the O4b `test_o4b_eventlist_6` campaign with `max lnL > 745` (S250114ax rift-v5PHM-calmarg and rift-NRSur7dq4), both with median chi-square ESS ~1.8 and 98–100% of points exhausting `--n-max`, against 77 and 0.31% for the other 138 runs.
2. Whether `mcsamplerAV` should refuse to report at k-hat > 10 / ESS < 2 rather than returning a finite `lnL` with a `sigma` that understates its error 17-fold. The `[AV COLLAPSE]` diagnostic already prints; it does not gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
