### PR TITLE
Fix calmarg forwarding of ChooseFDModes frame options

### DIFF
--- a/MonteCarloMarginalizeCode/Code/RIFT/calmarg/rift_source.py
+++ b/MonteCarloMarginalizeCode/Code/RIFT/calmarg/rift_source.py
@@ -21,6 +21,11 @@ except:
         has_GWS=False
 
 
+def _hlmoft_with_extra_waveform_kwargs(P, Lmax, extra_waveform_kwargs):
+    """Generate RIFT modes with the caller's waveform options expanded."""
+    return lalsimutils.hlmoft(P, Lmax=Lmax, **extra_waveform_kwargs)
+
+
 def RIFT_lal_binary_black_hole_orig(
         frequency_array, mass_1, mass_2, luminosity_distance, spin_1x, spin_1y, spin_1z,
         spin_2x, spin_2y, spin_2z, lambda_1, lambda_2, iota, phase, **kwargs):
@@ -71,7 +76,7 @@ def RIFT_lal_binary_black_hole_orig(
         # Note several underlying interfaces like ChooseTDModes will enforce these conditions already, but not all. Better safe than sorry.
         P.phiref = 0
         P.incl = 0  # L direction frame
-        hlmT = lalsimutils.hlmoft(P,Lmax=Lmax,extra_waveform_kwargs=extra_waveform_kwargs) # extra needed to control ChooseFDWaveform
+        hlmT = _hlmoft_with_extra_waveform_kwargs(P, Lmax, extra_waveform_kwargs)
         P.phiref = phase
         P.incl =  iota # restore
         h22T = hlmT[(2,2)]
@@ -179,7 +184,7 @@ def RIFT_lal_binary_black_hole(
         # Note several underlying interfaces like ChooseTDModes will enforce these conditions already, but not all. Better safe than sorry.
         P.phiref = 0
         P.incl = 0  # L direction frame
-        hlmT = lalsimutils.hlmoft(P,Lmax=Lmax,extra_waveform_kwargs=extra_waveform_kwargs) # extra needed to control ChooseFDWaveform
+        hlmT = _hlmoft_with_extra_waveform_kwargs(P, Lmax, extra_waveform_kwargs)
         P.phiref = phase
         P.incl =  iota # restore
 
@@ -306,7 +311,7 @@ def RIFT_lal_eccentric_binary_black_hole(
         # Note several underlying interfaces like ChooseTDModes will enforce these conditions already, but not all. Better safe than sorry.
         P.phiref = 0
         P.incl = 0  # L direction frame
-        hlmT = lalsimutils.hlmoft(P,Lmax=Lmax,extra_waveform_kwargs=extra_waveform_kwargs) # extra needed to control ChooseFDWaveform
+        hlmT = _hlmoft_with_extra_waveform_kwargs(P, Lmax, extra_waveform_kwargs)
         P.phiref = phase
         P.incl =  iota # restore
 

--- a/MonteCarloMarginalizeCode/Code/test/test_calmarg_rift_source.py
+++ b/MonteCarloMarginalizeCode/Code/test/test_calmarg_rift_source.py
@@ -1,0 +1,23 @@
+from RIFT.calmarg import rift_source
+
+
+def test_hlmoft_expands_extra_waveform_kwargs(monkeypatch):
+    captured = {}
+
+    def fake_hlmoft(P, **kwargs):
+        captured["P"] = P
+        captured["kwargs"] = kwargs
+        return "modes"
+
+    monkeypatch.setattr(rift_source.lalsimutils, "hlmoft", fake_hlmoft)
+    P = object()
+    options = {"fd_L_frame": True, "no_condition": True}
+
+    result = rift_source._hlmoft_with_extra_waveform_kwargs(P, 4, options)
+
+    assert result == "modes"
+    assert captured == {
+        "P": P,
+        "kwargs": {"Lmax": 4, "fd_L_frame": True, "no_condition": True},
+    }
+    assert options == {"fd_L_frame": True, "no_condition": True}


### PR DESCRIPTION
## Summary

- Expand calmarg waveform options into the named hlmoft arguments.
- Apply the correction to the original BBH, current BBH, and eccentric source functions.
- Add a regression test proving fd_L_frame and sibling options reach hlmoft without mutating the caller dictionary.

## Why

PR 183 corrected the ChooseFDModes J-to-L rotation, but calibration reweighting supplied its options as one extra_waveform_kwargs catch-all keyword. hlmoft never read that nested bundle, so fd_L_frame remained false on the calmarg source path. XPHM calmarg could therefore use unrotated J-frame modes while ILE used L-frame modes.

## Adversarial validation

- Actual XPHM calmarg q=4 stress path received fd_L_frame, no_condition, and fd_alignment_postevent_time as named arguments; no nested extra_waveform_kwargs remained.
- Rotated versus deliberately unrotated plus strain changed by 0.644635, demonstrating that the test is sensitive to the missing forwarding.
- PR 183 waveform comparisons passed: fiducial overlap 0.999175, q=4 edge-on 0.996263, near-aligned 0.997735.
- Maximum intrinsic-mode change under a psi shift was 0 in all three cases.
- The regression test body passed in the supported RIFT Python 3.13 environment; both files compile and git diff --check passes.

## Environment caveat

The local LALSimulation 6.1.0 provides XPHM and XO4a but not XPNR. A pre-existing grouped optional import in RIFT consequently masks all three identifiers. For the waveform validation only, the installed XPHM identifier was restored at runtime so the PR 183 route could be exercised. No workaround for that separate compatibility defect is included here.